### PR TITLE
EASY-2680: simpleTransform for multiple datasets

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -38,9 +38,11 @@ object Command extends App with DebugEnhancedLogging {
     .doIfFailure { case NonFatal(e) => println(s"FAILED: ${ e.getMessage }") }
 
   private def runSubcommand(app: EasyFedora2vaultApp): Try[FeedBackMessage] = {
-    app.simpleTransform(
-      commandLine.datasetId(),
-      commandLine.outputDir(),
-    )
+    val outputDir = commandLine.outputDir()
+    if (commandLine.datasetId.isDefined)
+      app.simpleTransform(commandLine.datasetId(), outputDir)
+    else {
+      app.simpleTransForms(commandLine.inputFile(), outputDir)
+    }
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -39,10 +39,8 @@ object Command extends App with DebugEnhancedLogging {
 
   private def runSubcommand(app: EasyFedora2vaultApp): Try[FeedBackMessage] = {
     val outputDir = commandLine.outputDir()
-    if (commandLine.datasetId.isDefined)
-      app.simpleTransform(commandLine.datasetId(), outputDir)
-    else {
-      app.simpleTransForms(commandLine.inputFile(), outputDir)
-    }
+    commandLine.datasetId
+      .map(app.simpleTransform(_, outputDir)) // TODO curry to get rid of _, after/when merging with PR #2
+      .getOrElse(app.simpleTransForms(commandLine.inputFile(), outputDir))
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -39,10 +39,8 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
     input.lineIterator.map(datasetId => {
       val subDir = outputDir / datasetId.replaceAll("[^a-zA-Z0-9]+", "-")
       simpleTransform(datasetId, subDir)
-        .doIfSuccess(println)
         .doIfFailure { case t =>
           logger.error(s"$datasetId failed", t)
-          println(s"$datasetId failed: $t")
         }
     }).collectFirst { case t @ Failure(_) => t }
       .getOrElse(Success(s"All datasets in ${ input } saved as bags in ${ outputDir }"))

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -18,22 +18,35 @@ package nl.knaw.dans.easy.fedora2vault
 import java.io.InputStream
 import java.nio.file.Paths
 
-import better.files.File
+import better.files.{ File, StringExtensions }
 import com.yourmediashelf.fedora.client.FedoraClient
 import javax.naming.ldap.InitialLdapContext
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.fedora2vault.Command.FeedBackMessage
 import nl.knaw.dans.easy.fedora2vault.FoXml.{ getEmd, _ }
-import better.files.StringExtensions
+import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import scala.util.{ Success, Try }
+import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, Node, XML }
 
 class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLogging {
   lazy val fedoraProvider: FedoraProvider = new FedoraProvider(new FedoraClient(configuration.fedoraCredentials))
   lazy val ldapContext: InitialLdapContext = new InitialLdapContext(configuration.ldapEnv, null)
   private lazy val ldap = new Ldap(ldapContext)
+
+  def simpleTransForms(input: File, outputDir: File): Try[FeedBackMessage] = {
+    input.lineIterator.map(datasetId => {
+      val subDir = outputDir / datasetId.replaceAll("[^a-zA-Z0-9]+", "-")
+      simpleTransform(datasetId, subDir)
+        .doIfSuccess(println)
+        .doIfFailure { case t =>
+          logger.error(s"$datasetId failed", t)
+          println(s"$datasetId failed: $t")
+        }
+    }).collectFirst { case t @ Failure(_) => t }
+      .getOrElse(Success(s"All datasets in ${ input } saved as bags in ${ outputDir }"))
+  }
 
   def simpleTransform(datasetId: DatasetId, outputDir: File): Try[FeedBackMessage] = {
 

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -36,7 +36,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
   private lazy val ldap = new Ldap(ldapContext)
 
   def simpleTransForms(input: File, outputDir: File): Try[FeedBackMessage] = {
-    input.lineIterator.map(datasetId => {
+    input.lineIterator.filterNot(_.startsWith("#")).map(datasetId => {
       val subDir = outputDir / datasetId.replaceAll("[^a-zA-Z0-9]+", "-")
       simpleTransform(datasetId, subDir)
         .doIfFailure { case t =>

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -21,11 +21,12 @@ import better.files.File
 import javax.naming.NamingEnumeration
 import javax.naming.directory.{ BasicAttributes, SearchControls, SearchResult }
 import javax.naming.ldap.InitialLdapContext
+import nl.knaw.dans.easy.fedora2vault.Command.FeedBackMessage
 import nl.knaw.dans.easy.fedora2vault.fixture.{ FileSystemSupport, TestSupportFixture }
 import org.scalamock.scalatest.MockFactory
 import resource.managed
 
-import scala.util.Success
+import scala.util.{ Failure, Success, Try }
 import scala.xml.Elem
 
 class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport {
@@ -44,6 +45,45 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
   private class MockedApp() extends EasyFedora2vaultApp(null) {
     override lazy val fedoraProvider: FedoraProvider = mock[FedoraProvider]
     override lazy val ldapContext: InitialLdapContext = mock[MockedLdapContext]
+  }
+
+  private class OverriddenApp extends MockedApp {
+    /** overrides the method called by the method under test */
+    override def simpleTransform(datasetId: DatasetId, outputDir: File): Try[FeedBackMessage] = {
+      if (!datasetId.startsWith("success"))
+        Failure(new Exception(datasetId))
+      else {
+        outputDir.createFile()
+        Success(s"created $outputDir from $datasetId")
+      }
+    }
+  }
+
+  "simpleTransforms" should "report success" in {
+    val input = (testDir / "input").write(
+      """success:1
+        |success:2
+        |""".stripMargin
+    )
+    val outputDir = (testDir / "output").createDirectories()
+    new OverriddenApp().simpleTransForms(input, outputDir) shouldBe
+      Success(s"All datasets in $input saved as bags in $outputDir")
+    outputDir.list.toSeq.map(_.name) shouldBe Seq("success-1", "success-2")
+  }
+
+  it should "report failure" in {
+    val input = (testDir / "input").write(
+      """success:1
+        |failure:1
+        |success:2
+        |""".stripMargin
+    )
+    val outputDir = (testDir / "output").createDirectories()
+    new OverriddenApp().simpleTransForms(input, outputDir) should matchPattern {
+      case Failure(t) if t.getMessage == "failure:1" =>
+    }
+    outputDir.list.toSeq.map(_.name) shouldBe Seq("success-1")
+    // success-2 is not created because of a fail fast strategy
   }
 
   "simpleTransform" should "produce a bag with EMD" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -68,7 +68,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
     val outputDir = (testDir / "output").createDirectories()
     new OverriddenApp().simpleTransForms(input, outputDir) shouldBe
       Success(s"All datasets in $input saved as bags in $outputDir")
-    outputDir.list.toSeq.map(_.name) shouldBe Seq("success-1", "success-2")
+    outputDir.list.toSeq.map(_.name) should contain theSameElementsAs Seq("success-1", "success-2")
   }
 
   it should "report failure" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -83,7 +83,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
       case Failure(t) if t.getMessage == "failure:1" =>
     }
     outputDir.list.toSeq.map(_.name) shouldBe Seq("success-1")
-    // success-2 is not created because of a fail fast strategy
+  // success-2 is not created because of a fail fast strategy
   }
 
   "simpleTransform" should "produce a bag with EMD" in {


### PR DESCRIPTION
Fixes EASY-2680: simpleTransform for multiple datasets

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Build deploy on deasy, then:
```
rm -rf /vagrant/shared/f2vbags
easy-fedora2vault -i /vagrant/shared/f2v.txt -o /vagrant/shared/f2vbags simple
```
With datasets IDs in `/vagrant/shared/f2v.txt` (note that 10 is omitted because of a large and hence slow interview):
```
easy-dataset:1
easy-dataset:2
easy-dataset:3
easy-dataset:4
easy-dataset:5
easy-dataset:6
easy-dataset:7
easy-dataset:8
easy-dataset:9
easy-dataset:11
easy-dataset:12
easy-dataset:13
easy-dataset:14
easy-dataset:15
easy-dataset:16
easy-dataset:17
```

#### Related pull requests on github
Will cause (easy to merge?) conflicts with #2
