### PR TITLE
EASY-2678 create files.xml

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.fedora2vault
 
 import java.io.{ IOException, InputStream }
-import java.nio.file.{ Path, Paths }
+import java.nio.file.Paths
 import java.util.UUID
 
 import better.files.{ File, StringExtensions }
@@ -35,7 +35,7 @@ import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
-import scala.xml.{ Elem, Node }
+import scala.xml.{ Elem, Node, NodeSeq }
 
 class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLogging {
   lazy val fedoraProvider: FedoraProvider = new FedoraProvider(new FedoraClient(configuration.fedoraCredentials))
@@ -106,7 +106,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
         .map(addXmlMetadata(bag, "depositor-info/message-from-depositor.txt"))
         .getOrElse(Success(())) // TODO EASY-2697: EMD/other/remark
       _ <- getFilesXml(foXml)
-        .map(addXmlMetadata(bag, "files.xml"))
+        .map(addXmlPayload(bag, "original-files.xml"))
         .getOrElse(Success(()))
       _ <- getAgreementsXml(foXml)
         .map(addAgreements(bag))
@@ -117,9 +117,10 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       _ <- managedMetadataStream(foXml, "DATASET_LICENSE", bag, "depositor-info/depositor-agreement") // TODO EASY-2697: older versions
         .getOrElse(Success(()))
       fedoraIDs <- fedoraProvider.getSubordinates(datasetId)
-      _ <- fedoraIDs.toStream
+      fileMetadata <- fedoraIDs.toStream
         .withFilter(_.startsWith("easy-file:"))
-        .map(addPayloadFileTo(bag)).failFastOr(Success(()))
+        .map(addPayloadFileTo(bag)).collectResults
+      _ <- addXmlMetadata(bag, "files.xml")(FileMetadata(fileMetadata))
       _ <- bag.save()
       _ <- getManifest(foXml)
         .map(compareManifest(bag))
@@ -151,16 +152,17 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
     bag.addTagFile(content.serialize.inputStream, Paths.get(path))
   }
 
-  private def addPayloadFileTo(bag: DansV0Bag)(fedoraFileId: String): Try[Path] = {
+  private def addPayloadFileTo(bag: DansV0Bag)(fedoraFileId: String): Try[NodeSeq] = {
     fedoraProvider.loadFoXml(fedoraFileId)
       .flatMap { foXml =>
-        val path = Paths.get((foXml \\ "file-item-md" \\ "path").text)
+        val metadata = foXml \\ "file-item-md"
+        val path = Paths.get((metadata \\ "path").text)
         logger.info(s"Adding $fedoraFileId to $path")
         fedoraProvider
           .disseminateDatastream(fedoraFileId, "EASY_FILE")
           .map(bag.addPayloadFile(_, path))
           .tried.flatten
-          .map(_ => path)
+          .map(_ => metadata)
       }
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -152,7 +152,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
     bag.addTagFile(content.serialize.inputStream, Paths.get(path))
   }
 
-  private def addPayloadFileTo(bag: DansV0Bag)(fedoraFileId: String): Try[NodeSeq] = {
+  private def addPayloadFileTo(bag: DansV0Bag)(fedoraFileId: String): Try[Option[NodeSeq]] = {
     fedoraProvider.loadFoXml(fedoraFileId)
       .flatMap { foXml =>
         val metadata = foXml \\ "file-item-md"
@@ -162,7 +162,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
           .disseminateDatastream(fedoraFileId, "EASY_FILE")
           .map(bag.addPayloadFile(_, path))
           .tried.flatten
-          .map(_ => metadata)
+          .map(_ => FoXml.getStreamRoot("EASY_FILE_METADATA",foXml))
       }
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
@@ -18,20 +18,20 @@ package nl.knaw.dans.easy.fedora2vault
 import scala.xml.{ Elem, NodeSeq }
 
 object FileMetadata {
-  def apply(nodes: Seq[NodeSeq]): Elem = {
+  def apply(dataStreams: Seq[Option[NodeSeq]]): Elem = {
     <files xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/files/ https://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
       {
-        nodes.map(fileItemMd =>
-          <file filepath={ "data/" + (fileItemMd \ "path").text }>
-            <dcterms:title>{ (fileItemMd \ "name").text }</dcterms:title>
-            <dcterms:format>{ (fileItemMd \ "mimeType").text }</dcterms:format>
-            <dcterms:created>{ (fileItemMd \ "created").text }</dcterms:created>
-            <accessibleToRights>{ (fileItemMd \ "visibleTo").text }</accessibleToRights>
-            <visibleToRights>{ (fileItemMd \ "accessibleTo").text }</visibleToRights>
+        dataStreams.map(_.map(stream =>
+          <file filepath={ "data/" + (stream \\ "path").text }>
+            <dcterms:title>{ (stream \\ "name").text }</dcterms:title>
+            <dcterms:format>{ (stream \\ "mimeType").text }</dcterms:format>
+            <dcterms:created>{ (stream \\ "datastreamVersion").head.attribute("CREATED").map(_.text).getOrElse("") }</dcterms:created>
+            <accessibleToRights>{ (stream \\ "visibleTo").text }</accessibleToRights>
+            <visibleToRights>{ (stream \\ "accessibleTo").text }</visibleToRights>
           </file>
-        )
+        ).getOrElse(""))
       }
     </files>
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.fedora2vault
+
+import scala.xml.{ Elem, NodeSeq }
+
+object FileMetadata {
+  def apply(nodes: Seq[NodeSeq]): Elem = {
+    <files xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/files/ https://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+      {
+        nodes.map(fileItemMd =>
+          <file filepath={ "data/" + (fileItemMd \ "path").text }>
+            <dcterms:title>{ (fileItemMd \ "name").text }</dcterms:title>
+            <dcterms:format>{ (fileItemMd \ "mimeType").text }</dcterms:format>
+            <dcterms:created>{ (fileItemMd \ "created").text }</dcterms:created>
+            <accessibleToRights>{ (fileItemMd \ "visibleTo").text }</accessibleToRights>
+            <visibleToRights>{ (fileItemMd \ "accessibleTo").text }</visibleToRights>
+          </file>
+        )
+      }
+    </files>
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
@@ -27,7 +27,6 @@ object FileMetadata {
           <file filepath={ "data/" + (stream \\ "path").text }>
             <dcterms:title>{ (stream \\ "name").text }</dcterms:title>
             <dcterms:format>{ (stream \\ "mimeType").text }</dcterms:format>
-            <dcterms:created>{ (stream \\ "datastreamVersion").head.attribute("CREATED").map(_.text).getOrElse("") }</dcterms:created>
             <accessibleToRights>{ (stream \\ "accessibleTo").text }</accessibleToRights>
             <visibleToRights>{ (stream \\ "visibleTo").text }</visibleToRights>
           </file>

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/FileMetadata.scala
@@ -28,8 +28,8 @@ object FileMetadata {
             <dcterms:title>{ (stream \\ "name").text }</dcterms:title>
             <dcterms:format>{ (stream \\ "mimeType").text }</dcterms:format>
             <dcterms:created>{ (stream \\ "datastreamVersion").head.attribute("CREATED").map(_.text).getOrElse("") }</dcterms:created>
-            <accessibleToRights>{ (stream \\ "visibleTo").text }</accessibleToRights>
-            <visibleToRights>{ (stream \\ "accessibleTo").text }</visibleToRights>
+            <accessibleToRights>{ (stream \\ "accessibleTo").text }</accessibleToRights>
+            <visibleToRights>{ (stream \\ "visibleTo").text }</visibleToRights>
           </file>
         ).getOrElse(""))
       }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/FoXml.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/FoXml.scala
@@ -33,7 +33,7 @@ object FoXml {
       .last
   }
 
-  private def getStreamRoot(streamId: String, foXml: Node): Option[Node] = {
+  def getStreamRoot(streamId: String, foXml: Node): Option[Node] = {
     (foXml \ "datastream")
       .theSeq
       .filter(n => n \@ "ID" == streamId)

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -165,9 +165,8 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
         |<file filepath="data/original/P1130783.JPG">
         |<dcterms:title>P1130783.JPG</dcterms:title>
         |<dcterms:format>image/jpeg</dcterms:format>
-        |<dcterms:created>2020-03-17T10:24:17.660Z</dcterms:created>
-        |<accessibleToRights>ANONYMOUS</accessibleToRights>
-        |<visibleToRights>RESTRICTED_REQUEST</visibleToRights>
+        |<accessibleToRights>RESTRICTED_REQUEST</accessibleToRights>
+        |<visibleToRights>ANONYMOUS</visibleToRights>
         |</file>
         |</files>""".stripMargin
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -151,7 +151,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
     sb.toString.startsWith("easy-dataset:13\tnull\tuser001\tsimple\t")
     val bag = (testDir / "bags").children.next()
     (bag / "metadata").list.toSeq.map(_.name)
-      .sortBy(identity) shouldBe Seq("amd.xml", "dataset.xml", "depositor-info", "emd.xml")
+      .sortBy(identity) shouldBe Seq("amd.xml", "dataset.xml", "depositor-info", "emd.xml", "files.xml")
     (bag / "metadata" / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
       Seq("agreements.xml")
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -127,12 +127,12 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
     val sb = new JavaStringBuilder()
     app.simpleTransform(testDir / "bags" / UUID.randomUUID.toString)("easy-dataset:17")(csvPrinter(sb)) shouldBe Success("OK")
     sb.toString.startsWith("easy-dataset:17\t10.17026/test-Iiib-z9p-4ywa\tuser001\tsimple\t")
-    val bag = (testDir / "bags").children.next()
-    (bag / "metadata" / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
-    (bag / "metadata" / "license.pdf").contentAsString shouldBe "lalala"
-    (bag / "metadata").list.toSeq.map(_.name).sortBy(identity) shouldBe
+    val metadata = (testDir / "bags").children.next() / "metadata"
+    (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
+    (metadata / "license.pdf").contentAsString shouldBe "lalala"
+    metadata.list.toSeq.map(_.name).sortBy(identity) shouldBe
       Seq("amd.xml", "dataset.xml", "depositor-info", "emd.xml", "files.xml", "license.pdf")
-    (bag / "metadata" / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
+    (metadata / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
       Seq("agreements.xml", "depositor-agreement.pdf", "message-from-depositor.txt")
   }
 
@@ -144,16 +144,32 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
     ))
     expectAUser(app.ldapContext)
     expectedFoXmls(app.fedoraProvider, sampleFoXML / "streaming.xml")
-    expectedSubordinates(app.fedoraProvider)
+    expectedSubordinates(app.fedoraProvider, "easy-file:35")
+    expectedFoXmls(app.fedoraProvider, sampleFoXML / "easy-file-35.xml")
+    expectedManagedStreams(app.fedoraProvider,
+      (testDir / "something.txt").writeText("don't care")
+    )
 
     val sb = new JavaStringBuilder()
     app.simpleTransform(testDir / "bags" / UUID.randomUUID.toString)("easy-dataset:13")(csvPrinter(sb)) shouldBe Success("OK")
     sb.toString.startsWith("easy-dataset:13\tnull\tuser001\tsimple\t")
-    val bag = (testDir / "bags").children.next()
-    (bag / "metadata").list.toSeq.map(_.name)
+    val metadata = (testDir / "bags").children.next() / "metadata"
+    metadata.list.toSeq.map(_.name)
       .sortBy(identity) shouldBe Seq("amd.xml", "dataset.xml", "depositor-info", "emd.xml", "files.xml")
-    (bag / "metadata" / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
+    (metadata / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
       Seq("agreements.xml")
+    (metadata / "files.xml").contentAsString.split("\n").map(_.trim).mkString("\n") shouldBe
+      """<?xml version='1.0' encoding='UTF-8'?>
+        |<files
+        |xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/files/ https://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:dcterms="http://purl.org/dc/terms/">
+        |<file filepath="data/original/P1130783.JPG">
+        |<dcterms:title>P1130783.JPG</dcterms:title>
+        |<dcterms:format>image/jpeg</dcterms:format>
+        |<dcterms:created>2020-03-17T10:24:17.660Z</dcterms:created>
+        |<accessibleToRights>ANONYMOUS</accessibleToRights>
+        |<visibleToRights>RESTRICTED_REQUEST</visibleToRights>
+        |</file>
+        |</files>""".stripMargin
   }
 
   private def csvPrinter(sb: JavaStringBuilder): CSVPrinter = {


### PR DESCRIPTION
Fixes EASY-2678 create files.xml

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

see #4 then
`grep '>' /vagrant/shared/f2vbags/*/metadata/files.xml`

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
