### PR TITLE
NO-JIRA: Remove file-metadata option from commandline

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ EXAMPLES
         easy-dataset:1001 is transformed according to the simple transformation, but only if it fulfils the requirements. The AIP bag is generated in directory '~/stagedAIPs'.
     
     $ easy-fedora2vault -s -u testDepositor -i dataset_ids.txt -o ./stagedAIPs -l ./outputLogfile.csv simple
-        creates a bag in './stagedAIPs' for each dataset in 'dataset_ids.txt' from depositor 'testDepositor' using the 'simple' transformation. If a dataset does not adhere to the 'simple' requirements, or is not deposited by 'testDepositor', it will not be considered and an explanation will be recorded in 'outputLogfile.csv'. 
+        creates a bag in './stagedAIPs' for each dataset in 'dataset_ids.txt' deposited by 'testDepositor' using the 'simple' transformation. If a dataset does not adhere to the 'simple' requirements, or is not deposited by 'testDepositor', it will not be considered and an explanation will be recorded in 'outputLogfile.csv'. 
 
 
 RESULTING FILES

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,12 @@ easy-fedora2vault
 ==============
 [![Build Status](https://travis-ci.org/DANS-KNAW/easy-fedora2vault.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-fedora2vault)
 
-Index a bag store
+Retrieves a dataset from Fedora and transforms it to an AIP bag conforming to DANS-BagIt-Profile v0
 
 SYNOPSIS
 --------
 
-    easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-f <file-metadata>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
-    easy-fedora2vault -d <dataset-id> -o <staged-AIP-dir> <transformation>
-    easy-fedora2vault -s -u <depositor> -i <dataset-ids-file> -o <staged-AIP-dir> -l <log-file> <transformation>
+    easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
 
 DESCRIPTION
 -----------
@@ -22,7 +20,6 @@ ARGUMENTS
                                argument
      -u, --depositor  <arg>    The depositor for these datasets. If provided, only datasets from this depositor
                                are transformed.
-     -f, --file-list  <arg>    A csv-file with metadata about extra files to be added to the AIP bag
      -i, --input-file  <arg>   File containing a newline-separated list of easy-dataset-ids to be transformed.
                                Use either this or the dataset-id argument
      -l, --log-file  <arg>     The name of the logfile in csv format. If not provided a file
@@ -47,8 +44,36 @@ EXAMPLES
     $ easy-fedora2vault -d easy-dataset:1001 -s -o ~/stagedAIPs simple
         easy-dataset:1001 is transformed according to the simple transformation, but only if it fulfils the requirements. The AIP bag is generated in directory '~/stagedAIPs'.
     
-    $ easy-fedora2vault -s -u testDepositor -i dataset_ids.txt -o ./stagedAIPs -l ./outputLogfile.csv -f file-metadata.csv simple
-        creates a bag in './stagedAIPs' for each dataset in 'dataset_ids.txt' from depositor 'testDepositor' using the 'simple' transformation. If a dataset does not adhere to the 'simple' requirements, or is not deposited by 'testDepositor', it will not be considered and an explanation will be recorded in 'outputLogfile.csv'. If the dataset-id is present in the 'file-metadata.csv' the metadata will be added to the files.xml and the referenced file will be added to the bag's payload.
+    $ easy-fedora2vault -s -u testDepositor -i dataset_ids.txt -o ./stagedAIPs -l ./outputLogfile.csv simple
+        creates a bag in './stagedAIPs' for each dataset in 'dataset_ids.txt' from depositor 'testDepositor' using the 'simple' transformation. If a dataset does not adhere to the 'simple' requirements, or is not deposited by 'testDepositor', it will not be considered and an explanation will be recorded in 'outputLogfile.csv'. 
+
+
+RESULTING FILES
+---------------
+For every dataset in the output there is a bag-dir created in the `<output-dir>`. This bag-dir contains the transformed metadata and data in a DANS-Bagit-Profile AIP and is named with a UUID.
+Furthermore, a `<log-file>` is generated in csv format with the following headers:
+
+    easy-dataset-id  input easy-dataset-id
+    UUID             UUID created for the resulting AIP
+    doi              doi as it appears in the EMD
+    depositor        EASY-User-Account of the depositor of the dataset
+    transformation   transformation used
+    comments         if the dataset does not conform to the transformation-requirements, it is chronicled here
+
+
+TRANSFORMATIONS
+---------------
+### SIMPLE
+A simple transformation transforms the dataset, with no consideration of other datasets, 'thematische collecties' or external storage.  
+With the option `--strict` the transformation will check that the input dataset conforms to the following requirements. The dataset
+
+* has a DANS-DOI
+* is PUBLISHED
+* is REQUEST\_PERMISSION or OPEN\_ACCESS
+* has no Jumpoff page (i.e. there is no dans-jumpoff object in Fedora with a isJumpoffPageFor relation to this dataset)
+* has no `replaces` or `isVersionOf` relation that references a DANS-DOI, DANS-URN or easy-dataset-id
+* is no `thematische collectie` (i.e. the title does not contain `thematische collectie`)
+* is not in the vault already (i.e. check in `easy-bag-index`)
 
 
 INSTALLATION AND CONFIGURATION

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -31,9 +31,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Tool for exporting datasets from Fedora and constructing AIP-bags to be stored in the bag stores"""
   val synopsis: String =
     s"""
-       |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-f <file-metadata>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
-       |  easy-fedora2vault -d <dataset-id> -o <staged-AIP-dir> <transformation>
-       |  easy-fedora2vault -s -u <depositor> -i <dataset-ids-file> -o <staged-AIP-dir> -l <log-file> <transformation>""".stripMargin
+       |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
+     """.stripMargin
 
   version(s"$printedName v${ configuration.version }")
   banner(
@@ -54,9 +53,6 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   private val inputPath: ScallopOption[Path] = opt(name = "input-file", short = 'i',
     descr = "File containing a newline-separated list of easy-dataset-ids to be transformed. Use either this or the dataset-id argument")
   val inputFile: ScallopOption[File] = inputPath.map(File(_))
-  private val fileListPath: ScallopOption[Path] = opt(name = "file-list", short = 'f',
-    descr = "A csv-file with metadata about extra files to be added to the AIP bag")
-  val fileList: ScallopOption[File] = fileListPath.map(File(_))
   private val outputDirPath: ScallopOption[Path] = opt(name = "output-dir", short = 'o',
     descr = "Empty directory in which to stage the created AIP bags. It will be created if it doesn't exist.")
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
@@ -75,9 +71,6 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
   validatePathExists(inputPath)
   validatePathIsFile(inputPath)
-
-  validatePathExists(fileListPath)
-  validatePathIsFile(fileListPath)
 
   validate(outputDir)(dir => {
     if (dir.exists) {


### PR DESCRIPTION
NO EASY

#### When applied it will...
* Add 'strict' rules to readme
* Remove -f option from readme
* Add description of output logfile

#### Where should the reviewer @DANS-KNAW/easy start?


