### PR TITLE
EASY-2732 check strict only when specified

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/BagIndex.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/BagIndex.scala
@@ -29,7 +29,7 @@ case class BagIndex(bagIndexUri: URI) {
   /** An IOException is fatal for the batch of datasets */
   private case class BagIndexException(msg: String, cause: Throwable) extends IOException(msg, cause)
 
-  private val url: URI = bagIndexUri.resolve("search")
+  private val url: URI = bagIndexUri.resolve("/search")
 
   def bagInfoByDoi(doi: String): Try[Option[String]] = for {
     maybeString <- findBagInfo(doi)
@@ -42,7 +42,7 @@ case class BagIndex(bagIndexUri: URI) {
   }.recoverWith {
     case t: Throwable => Failure(BagIndexException(s"DOI[$doi] url[$url]" + t.getMessage, t))
   }.map {
-    case response if response.code == 400 => None
+    case response if response.code == 404 => None
     case response if response.code == 200 => Some(response.body)
     case response =>
       throw BagIndexException(s"Not expected response code from bag-index. url='${ url }', doi='$doi', response: ${ response.code } - ${ response.body }", null)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -49,7 +49,7 @@ object Command extends App with DebugEnhancedLogging {
           ),
         commandLine.outputDir(),
         commandLine.logFile().newFileWriter(append = true),
-      )
+      ).map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")
     }
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -48,6 +48,7 @@ object Command extends App with DebugEnhancedLogging {
             .filterNot(_.startsWith("#"))
           ),
         commandLine.outputDir(),
+        commandLine.strictMode(),
         commandLine.logFile().newFileWriter(append = true),
       ).map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")
     }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -59,8 +59,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',
     descr = "The depositor for these datasets. If provided, only datasets from this depositor are transformed.")
   private val logFilePath: ScallopOption[Path] = opt(name = "log-file", short = 'l',
-    descr = "The name of the logfile in csv format. If not provided a file easy-fedora2vault-<timestamp>.csv will be created in the home-dir of the user.",
-    default = Some(Paths.get(Properties.userHome).resolve(s"easy-fedora2vault-$now.csv")))
+    descr = s"The name of the logfile in csv format. If not provided a file $printedName-<timestamp>.csv will be created in the home-dir of the user.",
+    default = Some(Paths.get(Properties.userHome).resolve(s"$printedName-$now.csv")))
   val logFile: ScallopOption[File] = logFilePath.map(File(_))
   val strictMode: ScallopOption[Boolean] = opt(name = "strict", short = 's',
     descr = "If provided, the transformation will check whether the datasets adhere to the requirements of the chosen transformation.")

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -53,7 +53,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   private val inputPath: ScallopOption[Path] = opt(name = "input-file", short = 'i',
     descr = "File containing a newline-separated list of easy-dataset-ids to be transformed. Use either this or the dataset-id argument")
   val inputFile: ScallopOption[File] = inputPath.map(File(_))
-  private val outputDirPath: ScallopOption[Path] = opt(name = "output-dir", short = 'o',
+  private val outputDirPath: ScallopOption[Path] = opt(name = "output-dir", short = 'o', required = true,
     descr = "Empty directory in which to stage the created AIP bags. It will be created if it doesn't exist.")
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
   val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
@@ -18,7 +18,6 @@ package nl.knaw.dans.easy.fedora2vault
 import java.util.UUID
 
 import nl.knaw.dans.easy.fedora2vault.Command.FeedBackMessage
-import nl.knaw.dans.easy.fedora2vault.TransformationType.TransformationType
 import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 
 import scala.util.Try
@@ -27,7 +26,7 @@ case class CsvRecord(easyDatasetId: DatasetId,
                      bagUUID: UUID,
                      doi: String,
                      depositor: Depositor,
-                     transformationType: TransformationType,
+                     transformationType: String,
                      comment: String,
                     ) {
   def print(implicit printer: CSVPrinter): Try[FeedBackMessage] = Try {

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -58,7 +58,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
   private def simpleTransForms(input: Iterator[DatasetId], outputDir: File)
                               (printer: CSVPrinter): Try[FeedBackMessage] = input
     .map(simpleTransform(_, outputDir / UUID.randomUUID.toString, printer))
-    .failFastOr(Success("OK"))
+    .failFastOr(Success("no fedora/IO errors"))
 
   private def simpleTransform(datasetId: DatasetId, bagDir: File, printer: CSVPrinter): Try[Any] = {
     simpleTransform(datasetId, bagDir)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -101,6 +101,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       fedoraIDs <- fedoraProvider.getSubordinates(datasetId)
       jumpOffIds = fedoraIDs.filter(_.startsWith("easy-jumpoff:"))
       maybeSimpleViolations <- simpleChecker.violations(emd, ddm, amd, jumpOffIds)
+      _ = println(s"maybeSimpleViolations=$maybeSimpleViolations")
       _ = if (strict) maybeSimpleViolations.foreach(msg => throw NotSimpleException(msg))
       bag <- DansV0Bag.empty(bagDir)
         .map(_.withEasyUserAccount(depositor).withCreated(DateTime.now()))

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -110,7 +110,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       _ <- addXmlMetadata(bag, "dataset.xml")(ddm)
       _ <- getMessageFromDepositor(foXml)
         .map(addXmlMetadata(bag, "depositor-info/message-from-depositor.txt"))
-        .getOrElse(Success(())) // TODO EASY-2697: EMD/other/remark
+        .getOrElse(Success(()))
       _ <- getFilesXml(foXml)
         .map(addXmlPayload(bag, "original-files.xml"))
         .getOrElse(Success(()))

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -68,7 +68,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       case t: FedoraClientException if t.getStatus != 404 => Failure(t)
       case t: Exception if t.isInstanceOf[IOException] => Failure(t)
       case t => Success(CsvRecord(
-        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE, s"FAILED: $t"
+        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE.toString, s"FAILED: $t"
       ))
     }
       .doIfSuccess(_.print(printer))
@@ -131,7 +131,15 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       _ <- addXmlMetadata(bag, "files.xml")(filesXml(fileItems))
       _ <- bag.save()
       doi = emd.getEmdIdentifier.getDansManagedDoi
-    } yield CsvRecord(datasetId, UUID.fromString(bagDir.name), doi, depositor, SIMPLE, comment)
+    } yield CsvRecord(
+      datasetId,
+      UUID.fromString(bagDir.name),
+      doi,
+      depositor,
+      transformationType = if (simpleViolations.isEmpty) "simple"
+                           else "not strict simple",
+      comment,
+    )
   }
 
   private def startWith(searchValue: String, in: Seq[String]): Seq[String] = {

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -91,7 +91,6 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       foXml <- fedoraProvider.loadFoXml(datasetId)
       depositor <- getOwner(foXml)
       msg = s"$bagDir from $datasetId with owner $depositor"
-      _ = logger.info("Created " + msg)
       emdXml <- getEmd(foXml)
       emd <- Try(emdUnmarshaller.unmarshal(emdXml.serialize))
       amd <- getAmd(foXml)
@@ -103,6 +102,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       maybeSimpleViolations <- simpleChecker.violations(emd, ddm, amd, jumpOffIds)
       _ = println(s"maybeSimpleViolations=$maybeSimpleViolations")
       _ = if (strict) maybeSimpleViolations.foreach(msg => throw NotSimpleException(msg))
+      _ = logger.info("Creating " + msg)
       bag <- DansV0Bag.empty(bagDir)
         .map(_.withEasyUserAccount(depositor).withCreated(DateTime.now()))
       _ <- addXmlMetadata(bag, "emd.xml")(emdXml)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -63,14 +63,14 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
   private def simpleTransform(datasetId: DatasetId, bagDir: File, strict: Boolean, printer: CSVPrinter): Try[Any] = {
     simpleTransform(datasetId, bagDir, strict)
       .doIfFailure {
-        case t: NotSimpleException => logger.warn(s"$datasetId -> $bagDir failed: ${t.getMessage}")
+        case t: NotSimpleException => logger.warn(s"$datasetId -> $bagDir failed: ${ t.getMessage }")
       }.recoverWith {
-        case t: FedoraClientException if t.getStatus != 404 => Failure(t)
-        case t: Exception if t.isInstanceOf[IOException] => Failure(t)
-        case t => Success(CsvRecord(
-          datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE, s"FAILED: $t"
-        ))
-      }
+      case t: FedoraClientException if t.getStatus != 404 => Failure(t)
+      case t: Exception if t.isInstanceOf[IOException] => Failure(t)
+      case t => Success(CsvRecord(
+        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE, s"FAILED: $t"
+      ))
+    }
       .doIfSuccess(_.print(printer))
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/SimpleChecker.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/SimpleChecker.scala
@@ -26,7 +26,7 @@ case class NotSimpleException(msg: String) extends Exception(msg)
 
 case class SimpleChecker(bagIndex: BagIndex) extends DebugEnhancedLogging {
 
-  def simpleViolations(emd: EasyMetadataImpl, ddm: Node, amd: Node, jumpOff: Seq[String]): Try[Seq[String]] = {
+  def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, jumpOff: Seq[String]): Try[Option[String]] = {
     val maybeDoi = Option(emd.getEmdIdentifier.getDansManagedDoi)
     val triedMaybeVaultResponse: Try[Option[String]] = maybeDoi
       .map(bagIndex.bagInfoByDoi)
@@ -46,8 +46,10 @@ case class SimpleChecker(bagIndex: BagIndex) extends DebugEnhancedLogging {
     violations.foreach { case (rule, violations) =>
       violations.foreach(s => mockFriendlyWarn(s"violated $rule $s"))
     }
+
     triedMaybeVaultResponse.map(_ =>
-      violations.keys.toSeq.filterNot(violations(_).isEmpty)
+      if (violations.isEmpty) None
+      else Some(violations.keys.mkString("Not simple, violates ", "; ", ""))
     )
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/SimpleChecker.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/SimpleChecker.scala
@@ -47,7 +47,7 @@ case class SimpleChecker(bagIndex: BagIndex) extends DebugEnhancedLogging {
       violations.foreach(s => mockFriendlyWarn(s"violated $rule $s"))
     }
     lazy val errorMessage: String = violations.keys
-      .map(_.replaceAll(":.*", ""))
+      //.map(_.replaceAll(":.*", ""))
       .mkString("Not a simple dataset. Violates rule ", ", ", "")
     for {
       _ <- triedMaybeVaultResponse // an IOException is not a violation

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/SimpleChecker.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/SimpleChecker.scala
@@ -49,7 +49,7 @@ case class SimpleChecker(bagIndex: BagIndex) extends DebugEnhancedLogging {
 
     triedMaybeVaultResponse.map(_ =>
       if (violations.isEmpty) None
-      else Some(violations.keys.mkString("Not simple, violates ", "; ", ""))
+      else Some(violations.keys.mkString("Violates ", "; ", ""))
     )
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -71,7 +71,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
     val ids = Iterator("success:1", "success:2")
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
-    new OverriddenApp().simpleTransForms(ids, outputDir, sw) shouldBe Success("OK")
+    new OverriddenApp().simpleTransForms(ids, outputDir, sw) shouldBe Success("no fedora/IO errors")
     sw.toString should (fullyMatch regex
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -140,7 +140,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false) shouldBe
-      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "not strict simple", "Not simple, violates 2: has jump off"))
+      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "not strict simple", "Violates 2: has jump off"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
     (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -56,6 +56,9 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
           Failure(new FedoraClientException(300, "mocked exception"))
+        case _ if datasetId.startsWith("notSimple") =>
+          outputDir.createFile().writeText(datasetId)
+          Failure(NotSimpleException("mocked"))
         case _ if !datasetId.startsWith("success") =>
           outputDir.createFile().writeText(datasetId)
           Failure(new Exception(datasetId))
@@ -81,7 +84,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
   }
 
   it should "report failure" in {
-    val ids = Iterator("success:1", "failure:2", "success:3", "fatal:4", "success:5")
+    val ids = Iterator("success:1", "failure:2", "notSimple:3", "success:4", "fatal:5", "success:6")
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
     new OverriddenApp().simpleTransForms(ids, outputDir, strict = true, sw) should matchPattern {
@@ -91,10 +94,11 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK
         |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
-        |success:3,.*,,,simple,OK
+        |notSimple:3,.*,,,simple,FAILED: nl.knaw.dans.easy.fedora2vault.NotSimpleException: mocked
+        |success:4,.*,,,simple,OK
         |""".stripMargin
       )
-    outputDir.list.toSeq should have length 3
+    outputDir.list.toSeq should have length 4
   }
 
   "simpleTransform" should "process DepositApi" in {
@@ -120,6 +124,47 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
       Seq("amd.xml", "dataset.xml", "depositor-info", "emd.xml", "files.xml", "license.pdf")
     (metadata / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
       Seq("agreements.xml", "depositor-agreement.pdf", "message-from-depositor.txt")
+  }
+
+  it should "report not strict simple violation" in {
+    val app = new MockedApp()
+    implicit val fedoraProvider: FedoraProvider = app.fedoraProvider
+    expectedAudiences(Map("easy-discipline:77" -> "D13200"))
+    expectNothingFrom(app.bagIndex)
+    expectedSubordinates(app.fedoraProvider, "easy-jumpoff:1")
+    expectedFoXmls(app.fedoraProvider, sampleFoXML / "DepositApi.xml")
+    expectedManagedStreams(app.fedoraProvider,
+      (testDir / "additional-license").write("lalala"),
+      (testDir / "dataset-license").write("blablabla"),
+    )
+
+    val uuid = UUID.randomUUID
+    app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false) shouldBe
+      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "not strict simple", "Not simple, violates 2: has jump off"))
+
+    val metadata = (testDir / "bags").children.next() / "metadata"
+    (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
+    (metadata / "license.pdf").contentAsString shouldBe "lalala"
+    metadata.list.toSeq.map(_.name).sortBy(identity) shouldBe
+      Seq("amd.xml", "dataset.xml", "depositor-info", "emd.xml", "files.xml", "license.pdf")
+    (metadata / "depositor-info").list.toSeq.map(_.name).sortBy(identity) shouldBe
+      Seq("agreements.xml", "depositor-agreement.pdf", "message-from-depositor.txt")
+  }
+
+  it should "report strict simple violation" in {
+    val app = new MockedApp()
+    implicit val fedoraProvider: FedoraProvider = app.fedoraProvider
+    expectedAudiences(Map("easy-discipline:77" -> "D13200"))
+    expectNothingFrom(app.bagIndex)
+    expectedSubordinates(app.fedoraProvider, "easy-jumpoff:1")
+    expectedFoXmls(app.fedoraProvider, sampleFoXML / "DepositApi.xml")
+
+    val uuid = UUID.randomUUID
+    app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true) should matchPattern {
+      case Failure(_: NotSimpleException) =>
+    }
+
+    (testDir / "bags") shouldNot exist
   }
 
   it should "process streaming" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -192,7 +192,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
   }
 
   private def expectNothingFrom(bagIndex: => BagIndex): Unit = {
-    (bagIndex.bagByDoi(_: String)) expects * once() returning Success(None)
+    (bagIndex.bagInfoByDoi(_: String)) expects * once() returning Success(None)
   }
 
   private def expectedManagedStreams(fedoraProvider: => FedoraProvider, expectedObjects: File*): Unit = {

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -24,7 +24,6 @@ import com.yourmediashelf.fedora.client.FedoraClientException
 import javax.naming.NamingEnumeration
 import javax.naming.directory.{ BasicAttributes, SearchControls, SearchResult }
 import javax.naming.ldap.InitialLdapContext
-import nl.knaw.dans.easy.fedora2vault.TransformationType.SIMPLE
 import nl.knaw.dans.easy.fedora2vault.fixture.{ AudienceSupport, FileSystemSupport, TestSupportFixture }
 import org.scalamock.scalatest.MockFactory
 import resource.managed
@@ -62,7 +61,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
           Failure(new Exception(datasetId))
         case _ =>
           outputDir.createFile().writeText(datasetId)
-          Success(CsvRecord(datasetId, UUID.randomUUID(), "", "", SIMPLE, "OK"))
+          Success(CsvRecord(datasetId, UUID.randomUUID(), "", "", "simple", "OK"))
       }
     }
   }
@@ -112,7 +111,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true) shouldBe
-      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", SIMPLE, "OK"))
+      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
     (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
@@ -138,7 +137,7 @@ class AppSpec extends TestSupportFixture with MockFactory with FileSystemSupport
     val uuid = UUID.randomUUID
     val triedRecord = app.simpleTransform("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true)
     triedRecord shouldBe
-      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", SIMPLE, "OK"))
+      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
     metadata.list.toSeq.map(_.name)

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
@@ -29,38 +29,38 @@ class BagIndexSpec extends TestSupportFixture with MockFactory {
   "bagInfoByDoi" should "return None" in {
     new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
       override def execute(doi: String): HttpResponse[String] =
-        new HttpResponse[String](body = "",code = 400,headers = Map.empty)
+        new HttpResponse[String](body = "", code = 400, headers = Map.empty)
     }.bagInfoByDoi("") shouldBe Success(None)
   }
 
-  it  should "return also None" in {
+  it should "return also None" in {
     new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
       override def execute(doi: String): HttpResponse[String] =
-        new HttpResponse[String](body = "<result/>",code = 200,headers = Map.empty)
+        new HttpResponse[String](body = "<result/>", code = 200, headers = Map.empty)
     }.bagInfoByDoi("") shouldBe Success(None)
   }
 
-  it  should "return Some" in {
+  it should "return Some" in {
     new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
       override def execute(doi: String): HttpResponse[String] =
-        new HttpResponse[String](body = "<result><bag-info>blabla</bag-info></result>",code = 200,headers = Map.empty)
+        new HttpResponse[String](body = "<result><bag-info>blabla</bag-info></result>", code = 200, headers = Map.empty)
     }.bagInfoByDoi("") shouldBe Success(Some("<bag-info>blabla</bag-info>"))
   }
 
-  it  should "return SAXParseException" in {
+  it should "return SAXParseException" in {
     new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
       override def execute(doi: String): HttpResponse[String] =
-        // TODO apply as bagIndexExpects in SimpleCheckerSpec
-        new HttpResponse[String](body = "",code = 200, headers = Map.empty)
+      // TODO apply as bagIndexExpects in SimpleCheckerSpec
+        new HttpResponse[String](body = "", code = 200, headers = Map.empty)
     }.bagInfoByDoi("") should matchPattern {
       case Failure(e: SAXParseException) if e.getMessage == "Premature end of file." =>
     }
   }
 
-  it  should "return not expected response code" in {
+  it should "return not expected response code" in {
     new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
       override def execute(doi: String): HttpResponse[String] =
-        new HttpResponse[String](body = "",code = 300,headers = Map.empty)
+        new HttpResponse[String](body = "", code = 300, headers = Map.empty)
     }.bagInfoByDoi("") should matchPattern {
       case Failure(e: Exception) if e.getMessage ==
         "Not expected response code from bag-index. url='https://does.not.exist.dans.knaw.nlsearch', doi='', response: 300 - " =>

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.fedora2vault
+
+import java.net.URI
+
+import nl.knaw.dans.easy.fedora2vault.fixture.TestSupportFixture
+import org.scalamock.scalatest.MockFactory
+import scalaj.http.HttpResponse
+
+import scala.util.{ Failure, Success }
+import scala.xml.SAXParseException
+
+class BagIndexSpec extends TestSupportFixture with MockFactory {
+
+  "bagInfoByDoi" should "return None" in {
+    new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
+      override def execute(doi: String): HttpResponse[String] =
+        new HttpResponse[String](body = "",code = 400,headers = Map.empty)
+    }.bagInfoByDoi("") shouldBe Success(None)
+  }
+
+  it  should "return also None" in {
+    new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
+      override def execute(doi: String): HttpResponse[String] =
+        new HttpResponse[String](body = "<result/>",code = 200,headers = Map.empty)
+    }.bagInfoByDoi("") shouldBe Success(None)
+  }
+
+  it  should "return Some" in {
+    new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
+      override def execute(doi: String): HttpResponse[String] =
+        new HttpResponse[String](body = "<result><bag-info>blabla</bag-info></result>",code = 200,headers = Map.empty)
+    }.bagInfoByDoi("") shouldBe Success(Some("<bag-info>blabla</bag-info>"))
+  }
+
+  it  should "return SAXParseException" in {
+    new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
+      override def execute(doi: String): HttpResponse[String] =
+        // TODO apply as bagIndexExpects in SimpleCheckerSpec
+        new HttpResponse[String](body = "",code = 200, headers = Map.empty)
+    }.bagInfoByDoi("") should matchPattern {
+      case Failure(e: SAXParseException) if e.getMessage == "Premature end of file." =>
+    }
+  }
+
+  it  should "return not expected response code" in {
+    new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
+      override def execute(doi: String): HttpResponse[String] =
+        new HttpResponse[String](body = "",code = 300,headers = Map.empty)
+    }.bagInfoByDoi("") should matchPattern {
+      case Failure(e: Exception) if e.getMessage ==
+        "Not expected response code from bag-index. url='https://does.not.exist.dans.knaw.nlsearch', doi='', response: 300 - " =>
+    }
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
@@ -29,7 +29,7 @@ class BagIndexSpec extends TestSupportFixture with MockFactory {
   "bagInfoByDoi" should "return None" in {
     new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
       override def execute(doi: String): HttpResponse[String] =
-        new HttpResponse[String](body = "", code = 400, headers = Map.empty)
+        new HttpResponse[String](body = "", code = 404, headers = Map.empty)
     }.bagInfoByDoi("") shouldBe Success(None)
   }
 
@@ -63,7 +63,7 @@ class BagIndexSpec extends TestSupportFixture with MockFactory {
         new HttpResponse[String](body = "", code = 300, headers = Map.empty)
     }.bagInfoByDoi("") should matchPattern {
       case Failure(e: Exception) if e.getMessage ==
-        "Not expected response code from bag-index. url='https://does.not.exist.dans.knaw.nlsearch', doi='', response: 300 - " =>
+        "Not expected response code from bag-index. url='https://does.not.exist.dans.knaw.nl/search', doi='', response: 300 - " =>
     }
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
@@ -60,7 +60,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 5: invalid state SUBMITTED",
       )
     ).isSimple(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) should matchPattern {
-      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 1, 5" =>
+      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 1: DANS DOI, 5: invalid state" =>
     }
   }
 
@@ -75,7 +75,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 4: invalid rights not found",
       )
     ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) should matchPattern {
-      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 3, 4" =>
+      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 3: invalid title, 4: invalid rights" =>
     }
   }
 
@@ -91,7 +91,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 4: invalid rights not found",
       )
     ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("easy-jumpoff:123")) should matchPattern {
-      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 2, 3, 4" =>
+      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 2: has jump off, 3: invalid title, 4: invalid rights" =>
     }
   }
 
@@ -105,7 +105,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 5: invalid state SUBMITTED",
       )
     ).isSimple(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) should matchPattern {
-      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 4, 5" =>
+      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 4: invalid rights, 5: invalid state" =>
     }
   }
 
@@ -131,7 +131,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
       )
     ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) should matchPattern {
-      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 6" =>
+      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 6: DANS relations" =>
     }
   }
 
@@ -142,7 +142,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
       expectedBagIndexResponse = new HttpResponse[String](body = s"<result>$result</result>", code = 200, headers = Map.empty),
       loggerWarnCalledWith = Seq(s"violated 7: is in the vault $result")
     ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) should matchPattern {
-      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 7" =>
+      case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 7: is in the vault" =>
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
@@ -21,8 +21,9 @@ import com.typesafe.scalalogging.Logger
 import nl.knaw.dans.easy.fedora2vault.fixture.{ EmdSupport, TestSupportFixture }
 import org.scalamock.scalatest.MockFactory
 import org.slf4j.{ Logger => UnderlyingLogger }
+import scalaj.http.HttpResponse
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 import scala.xml.Elem
 
 class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupport {
@@ -39,26 +40,26 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
                          >10.17026/test-Iiib-z9p-4ywa</dc:identifier>
                        </emd:identifier>
 
-  private val noBagInTheVault = Some(Success(None))
-  private val aBagInTheVault = Some(Success(Some("---")))
-
   "isSimple" should "succeed" in {
     val emdTitle = <emd:title><dc:title xml:lang="nld">no theme</dc:title></emd:title>
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
 
-    simpleCheckerExpecting(bagIndexExpects = noBagInTheVault, loggerWarnCalledWith = Seq())
-      .isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
+    simpleCheckerExpecting(
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      loggerWarnCalledWith = Seq()
+    ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
       Success(())
   }
 
   it should "report missing DOI" in {
     val emd = parseEmdContent(emdRights)
     simpleCheckerExpecting(
-      bagIndexExpects = None, // no call expected
+      expectedBagIndexResponse = null, // no call expected
       loggerWarnCalledWith = Seq(
         "violated 1: DANS DOI not found",
         "violated 5: invalid state SUBMITTED",
-      )).isSimple(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) should matchPattern {
+      )
+    ).isSimple(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) should matchPattern {
       case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 1, 5" =>
     }
   }
@@ -67,10 +68,13 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     val emdTitle = <emd:title><dc:title xml:lang="nld">thematische collectie</dc:title></emd:title>
     val emd = parseEmdContent(Seq(emdTitle, emdDoi))
 
-    simpleCheckerExpecting(bagIndexExpects = noBagInTheVault, loggerWarnCalledWith = Seq(
-      "violated 3: invalid title thematische collectie",
-      "violated 4: invalid rights not found",
-    )).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) should matchPattern {
+    simpleCheckerExpecting(
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      loggerWarnCalledWith = Seq(
+        "violated 3: invalid title thematische collectie",
+        "violated 4: invalid rights not found",
+      )
+    ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) should matchPattern {
       case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 3, 4" =>
     }
   }
@@ -79,11 +83,14 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     val emdTitle = <emd:title><dc:title xml:lang="nld">thematische collectie</dc:title></emd:title>
     val emd = parseEmdContent(Seq(emdTitle, emdDoi))
 
-    simpleCheckerExpecting(bagIndexExpects = noBagInTheVault, loggerWarnCalledWith = Seq(
-      "violated 2: has jump off easy-jumpoff:123",
-      "violated 3: invalid title thematische collectie",
-      "violated 4: invalid rights not found",
-    )).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("easy-jumpoff:123")) should matchPattern {
+    simpleCheckerExpecting(expectedBagIndexResponse = new HttpResponse[String](
+      body = "", code = 400, headers = Map.empty),
+      loggerWarnCalledWith = Seq(
+        "violated 2: has jump off easy-jumpoff:123",
+        "violated 3: invalid title thematische collectie",
+        "violated 4: invalid rights not found",
+      )
+    ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("easy-jumpoff:123")) should matchPattern {
       case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 2, 3, 4" =>
     }
   }
@@ -91,10 +98,13 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
   it should "report invalid status" in {
     val emd = parseEmdContent(emdDoi)
 
-    simpleCheckerExpecting(bagIndexExpects = noBagInTheVault, loggerWarnCalledWith = Seq(
-      "violated 4: invalid rights not found",
-      "violated 5: invalid state SUBMITTED",
-    )).isSimple(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) should matchPattern {
+    simpleCheckerExpecting(
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      loggerWarnCalledWith = Seq(
+        "violated 4: invalid rights not found",
+        "violated 5: invalid state SUBMITTED",
+      )
+    ).isSimple(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) should matchPattern {
       case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 4, 5" =>
     }
   }
@@ -113,20 +123,24 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
       </emd:relation>,
       emdRights
     ))
-    simpleCheckerExpecting(bagIndexExpects = noBagInTheVault, loggerWarnCalledWith = Seq(
-      "violated 6: DANS relations <dct:isVersionOf>https://doi.org/10.17026/test-123-456</dct:isVersionOf>",
-      "violated 6: DANS relations <dct:isVersionOf>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:isVersionOf>",
-      """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
-    )).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) should matchPattern {
+    simpleCheckerExpecting(
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      loggerWarnCalledWith = Seq(
+        "violated 6: DANS relations <dct:isVersionOf>https://doi.org/10.17026/test-123-456</dct:isVersionOf>",
+        "violated 6: DANS relations <dct:isVersionOf>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:isVersionOf>",
+        """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
+      )
+    ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) should matchPattern {
       case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 6" =>
     }
   }
 
   it should "report existing bag" in {
     val emd = parseEmdContent(Seq(emdDoi, emdRights))
+    val result = "<bag-info><bag-id>blabla</bag-id><doi>10.80270/test-zwu-cxjx</doi></bag-info>"
     simpleCheckerExpecting(
-      bagIndexExpects = aBagInTheVault,
-      loggerWarnCalledWith = Seq("violated 7: is in the vault ---")
+      expectedBagIndexResponse = new HttpResponse[String](body = s"<result>$result</result>", code = 200, headers = Map.empty),
+      loggerWarnCalledWith = Seq(s"violated 7: is in the vault $result")
     ).isSimple(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) should matchPattern {
       case Failure(t: Throwable) if t.getMessage == "Not a simple dataset. Violates rule 7" =>
     }
@@ -137,16 +151,13 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
       <datasetState>{ state }</datasetState>
     </damd:administrative-md>
 
-  private def simpleCheckerExpecting(bagIndexExpects: Option[Try[Option[String]]],
+  private def simpleCheckerExpecting(expectedBagIndexResponse: HttpResponse[String],
                                      loggerWarnCalledWith: Seq[String],
                                     ): SimpleChecker = {
-    val mockedBagIndex: MockedBagIndex = mock[MockedBagIndex]
-    bagIndexExpects.foreach(expected =>
-      (mockedBagIndex.bagByDoi(_: String)) expects * returning expected once()
-    )
-    bagIndexExpects.getOrElse(
-      (mockedBagIndex.bagByDoi(_: String)) expects * never()
-    )
+    val mockedBagIndex = new BagIndex(new URI("https://does.not.exist.dans.knaw.nl")) {
+      override def execute(doi: String): HttpResponse[String] =
+        expectedBagIndexResponse
+    }
 
     val mockLogger = mock[UnderlyingLogger]
     (() => mockLogger.isWarnEnabled()) expects() anyNumberOfTimes() returning true

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
@@ -47,8 +47,8 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     simpleCheckerExpecting(
       expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
       loggerWarnCalledWith = Seq()
-    ).simpleViolations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
-      Success(Seq.empty)
+    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
+      Success(None)
   }
 
   it should "report missing DOI" in {
@@ -59,8 +59,8 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 1: DANS DOI not found",
         "violated 5: invalid state SUBMITTED",
       )
-    ).simpleViolations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
-      Success(Seq("1: DANS DOI", "5: invalid state"))
+    ).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
+      Success(Some("Not simple, violates 1: DANS DOI; 5: invalid state"))
   }
 
   it should "report thematische collectie" in {
@@ -73,8 +73,8 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 3: invalid title thematische collectie",
         "violated 4: invalid rights not found",
       )
-    ).simpleViolations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) shouldBe
-      Success(Seq("3: invalid title", "4: invalid rights"))
+    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) shouldBe
+      Success(Some("Not simple, violates 3: invalid title; 4: invalid rights"))
   }
 
   it should "report jump off" in {
@@ -88,8 +88,8 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 3: invalid title thematische collectie",
         "violated 4: invalid rights not found",
       )
-    ).simpleViolations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("easy-jumpoff:123")) shouldBe
-      Success(Seq("2: has jump off", "3: invalid title", "4: invalid rights"))
+    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("easy-jumpoff:123")) shouldBe
+      Success(Some("Not simple, violates 2: has jump off; 3: invalid title; 4: invalid rights"))
   }
 
   it should "report invalid status" in {
@@ -101,8 +101,8 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 4: invalid rights not found",
         "violated 5: invalid state SUBMITTED",
       )
-    ).simpleViolations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
-      Success(Vector("4: invalid rights", "5: invalid state"))
+    ).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
+      Success(Some("Not simple, violates 4: invalid rights; 5: invalid state"))
   }
 
   it should "report invalid relations" in {
@@ -126,8 +126,8 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 6: DANS relations <dct:isVersionOf>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:isVersionOf>",
         """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
       )
-    ).simpleViolations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
-      Success(Seq("6: DANS relations"))
+    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
+      Success(Some("Not simple, violates 6: DANS relations"))
   }
 
   it should "report existing bag" in {
@@ -136,8 +136,8 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     simpleCheckerExpecting(
       expectedBagIndexResponse = new HttpResponse[String](body = s"<result>$result</result>", code = 200, headers = Map.empty),
       loggerWarnCalledWith = Seq(s"violated 7: is in the vault $result")
-    ).simpleViolations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
-      Success(Seq("7: is in the vault"))
+    ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
+      Success(Some("Not simple, violates 7: is in the vault"))
   }
 
   private def amd(state: String): Elem =

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
@@ -60,7 +60,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 5: invalid state SUBMITTED",
       )
     ).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
-      Success(Some("Not simple, violates 1: DANS DOI; 5: invalid state"))
+      Success(Some("Violates 1: DANS DOI; 5: invalid state"))
   }
 
   it should "report thematische collectie" in {
@@ -74,7 +74,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 4: invalid rights not found",
       )
     ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq()) shouldBe
-      Success(Some("Not simple, violates 3: invalid title; 4: invalid rights"))
+      Success(Some("Violates 3: invalid title; 4: invalid rights"))
   }
 
   it should "report jump off" in {
@@ -89,7 +89,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 4: invalid rights not found",
       )
     ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq("easy-jumpoff:123")) shouldBe
-      Success(Some("Not simple, violates 2: has jump off; 3: invalid title; 4: invalid rights"))
+      Success(Some("Violates 2: has jump off; 3: invalid title; 4: invalid rights"))
   }
 
   it should "report invalid status" in {
@@ -102,7 +102,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         "violated 5: invalid state SUBMITTED",
       )
     ).violations(emd, emd2ddm(emd), amd("SUBMITTED"), Seq.empty) shouldBe
-      Success(Some("Not simple, violates 4: invalid rights; 5: invalid state"))
+      Success(Some("Violates 4: invalid rights; 5: invalid state"))
   }
 
   it should "report invalid relations" in {
@@ -127,7 +127,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
         """violated 6: DANS relations <ddm:replaces scheme="id-type:URN" href="http://persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-aka-hff">Prehistorische bewoning op het World Forum gebied - Den Haag (replaces)</ddm:replaces>""",
       )
     ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
-      Success(Some("Not simple, violates 6: DANS relations"))
+      Success(Some("Violates 6: DANS relations"))
   }
 
   it should "report existing bag" in {
@@ -137,7 +137,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
       expectedBagIndexResponse = new HttpResponse[String](body = s"<result>$result</result>", code = 200, headers = Map.empty),
       loggerWarnCalledWith = Seq(s"violated 7: is in the vault $result")
     ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
-      Success(Some("Not simple, violates 7: is in the vault"))
+      Success(Some("Violates 7: is in the vault"))
   }
 
   private def amd(state: String): Elem =

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala
@@ -45,7 +45,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     val emd = parseEmdContent(Seq(emdTitle, emdDoi, emdRights))
 
     simpleCheckerExpecting(
-      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 404, headers = Map.empty),
       loggerWarnCalledWith = Seq()
     ).violations(emd, emd2ddm(emd), amd("PUBLISHED"), Seq.empty) shouldBe
       Success(None)
@@ -68,7 +68,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     val emd = parseEmdContent(Seq(emdTitle, emdDoi))
 
     simpleCheckerExpecting(
-      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 404, headers = Map.empty),
       loggerWarnCalledWith = Seq(
         "violated 3: invalid title thematische collectie",
         "violated 4: invalid rights not found",
@@ -82,7 +82,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     val emd = parseEmdContent(Seq(emdTitle, emdDoi))
 
     simpleCheckerExpecting(expectedBagIndexResponse = new HttpResponse[String](
-      body = "", code = 400, headers = Map.empty),
+      body = "", code = 404, headers = Map.empty),
       loggerWarnCalledWith = Seq(
         "violated 2: has jump off easy-jumpoff:123",
         "violated 3: invalid title thematische collectie",
@@ -96,7 +96,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
     val emd = parseEmdContent(emdDoi)
 
     simpleCheckerExpecting(
-      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 404, headers = Map.empty),
       loggerWarnCalledWith = Seq(
         "violated 4: invalid rights not found",
         "violated 5: invalid state SUBMITTED",
@@ -120,7 +120,7 @@ class SimpleCheckerSpec extends TestSupportFixture with MockFactory with EmdSupp
       emdRights
     ))
     simpleCheckerExpecting(
-      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 400, headers = Map.empty),
+      expectedBagIndexResponse = new HttpResponse[String](body = "", code = 404, headers = Map.empty),
       loggerWarnCalledWith = Seq(
         "violated 6: DANS relations <dct:isVersionOf>https://doi.org/10.17026/test-123-456</dct:isVersionOf>",
         "violated 6: DANS relations <dct:isVersionOf>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dct:isVersionOf>",

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/fixture/TestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/fixture/TestSupportFixture.scala
@@ -29,9 +29,4 @@ trait TestSupportFixture extends AnyFlatSpec with TimeZoneFixture
   with Inspectors {
   val nameSpaceRegExp = """ xmlns:[a-z-]+="[^"]*"""" // these attributes have a variable order
   val sampleFoXML: File = File("src/test/resources/sample-foxml")
-
-  val emdNS = "http://easy.dans.knaw.nl/easy/easymetadata/"
-  val easNS = "http://easy.dans.knaw.nl/easy/easymetadata/eas/"
-  val dctNS = "http://purl.org/dc/terms/"
-  val dcNS = "http://purl.org/dc/elements/1.1/"
 }


### PR DESCRIPTION
Fixes EASY-2732 check strict only when specified

#### When applied it will also...
* no more null pointer exception when omitting the mandatory -o argument
* examines what the bag-index returns between `<result></result>`
* verbose rule violation comment field
  https://github.com/DANS-KNAW/easy-fedora2vault/blob/b4ed821f665e59b123bebedfe24f2deb47717261/src/test/scala/nl/knaw/dans/easy/fedora2vault/SimpleCheckerSpec.scala#L108
* verbose feedback message `no fedora/IO errors, for details see /path/to/xxx.csv`
  https://github.com/DANS-KNAW/easy-fedora2vault/blob/bda05b2ab6647bddd56252b85913fac015beb1e8/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala#L74
  completed with
  https://github.com/DANS-KNAW/easy-fedora2vault/blob/bda05b2ab6647bddd56252b85913fac015beb1e8/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala#L53
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
