### PR TITLE
EASY-2744: EMD -> DDM spatial fields

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/DDM.scala
@@ -183,7 +183,7 @@ object DDM extends DebugEnhancedLogging {
       optional(emdPoint.getY),
     ))
     <dcx-gml:spatial srsName={ maybePoint.map(_.srsName).orNull }>
-      { Option(spatial.getPlace).toSeq.map(bs => <description xml:lang={ lang(bs) }>{ bs.getValue }</description>) }
+      { Option(spatial.getPlace).toSeq.map(bs => <name xml:lang={ lang(bs) }>{ bs.getValue }</name>) }
       { maybePoint.toSeq.map(toXml) }
       { Option(spatial.getBox).toSeq.map(toXml) }
       { Option(spatial.getPolygons.asScala).toSeq.map(toXml) }
@@ -223,7 +223,7 @@ object DDM extends DebugEnhancedLogging {
       override val value: Option[String] = None
     }.srsName
     val place = optional(polygon.getPlace)
-      .map(place => <description>{ place }</description>)
+      .map(place => <name>{ place }</name>)
       .getOrElse(Text(""))
     val exterior = Option(polygon.getExterior)
       .map(part => <exterior>{ toXml(part, maybeScheme) }</exterior>)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/DDM.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/DDM.scala
@@ -209,7 +209,7 @@ object DDM extends DebugEnhancedLogging {
     val exterior = Option(polygon.getExterior)
       .map(part => <exterior>{ toXml(part, maybeScheme) }</exterior>)
       .getOrElse(Text(""))
-    val interiors = Option(polygon.getExterior).toSeq
+    val interiors = Option(polygon.getInterior).toSeq.flatMap(_.asScala)
       .flatMap(part => <interior>{ toXml(part, maybeScheme) }</interior>)
     <dcx-gml:spatial>
         <Polygon xmlns='http://www.opengis.net/gml' srsName={ srsName }>

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -100,7 +100,6 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       fedoraIDs <- fedoraProvider.getSubordinates(datasetId)
       jumpOffIds = fedoraIDs.filter(_.startsWith("easy-jumpoff:"))
       maybeSimpleViolations <- simpleChecker.violations(emd, ddm, amd, jumpOffIds)
-      _ = println(s"maybeSimpleViolations=$maybeSimpleViolations")
       _ = if (strict) maybeSimpleViolations.foreach(msg => throw NotSimpleException(msg))
       _ = logger.info("Creating " + msg)
       bag <- DansV0Bag.empty(bagDir)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.fedora2vault
+
+// TODO copied from easy-deposit-api
+
+trait OptionalValue {
+  val value: Option[String]
+
+  lazy val hasValue: Boolean = value.exists(_.trim.nonEmpty)
+}
+
+object SpatialNames {
+  /** coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X) */
+  val DEGREES_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/4326"
+
+  /** coordinate order x, y = longitude (DCX_SPATIAL_X), latitude (DCX_SPATIAL_Y) */
+  val RD_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/28992"
+}
+
+trait SchemedSpatial extends OptionalValue {
+  val scheme: Option[String]
+
+  lazy val srsName: String = {
+    scheme match {
+      case Some("degrees") => SpatialNames.DEGREES_SRS_NAME
+      case Some("RD") => SpatialNames.RD_SRS_NAME
+      case Some(s) if s.trim.nonEmpty => s
+      case _ => null // will suppress the XML attribute
+    }
+  }
+}
+
+case class SpatialPoint(scheme: Option[String],
+                        x: Option[String],
+                        y: Option[String],
+                       ) extends SchemedSpatial {
+  private lazy val sx: String = x.getOrElse("0")
+  private lazy val sy: String = y.getOrElse("0")
+  lazy val pos: String = srsName match {
+    case SpatialNames.RD_SRS_NAME => s"$sx $sy"
+    case SpatialNames.DEGREES_SRS_NAME => s"$sy $sx"
+    case _ => s"$sy $sx"
+  }
+
+  override lazy val value: Option[String] = {
+    (x ++ y).headOption
+      .map(_ => pos)
+  }
+}
+
+case class SpatialBox(scheme: Option[String],
+                      north: Option[String],
+                      east: Option[String],
+                      south: Option[String],
+                      west: Option[String],
+                     ) extends SchemedSpatial {
+  private lazy val sWest: String = west.getOrElse("0")
+  private lazy val sSouth: String = south.getOrElse("0")
+  private lazy val sNorth: String = north.getOrElse("0")
+  private lazy val sEast: String = east.getOrElse("0")
+  private lazy val xy = (s"$sWest $sSouth", s"$sEast $sNorth")
+  private lazy val yx = (s"$sSouth $sWest", s"$sNorth $sEast")
+  /*
+   * Note that Y is along North - South and X is along East - West
+   * The lower corner is with the minimal coordinate values and upper corner with the maximal coordinate values
+   * If x was increasing from West to East and y was increasing from South to North we would have
+   * lower corner (x,y) = (West,South) and upper corner (x,y) = (East,North)
+   * as shown in the schematic drawing of the box below.
+   * This is the case for the WGS84 and RD coordinate systems, but not per se for any other system!
+   *
+   *                upper(x,y)=(E,N)
+   *       *---N---u
+   *       |       |
+   *       W       E
+   *  ^    |       |
+   *  |    l---S---*
+   *  |  lower(x,y)=(W,S)
+   *  y
+   *   x -->
+   *
+   */
+  lazy val (lower: String, upper: String) = srsName match {
+    case SpatialNames.RD_SRS_NAME => xy
+    case SpatialNames.DEGREES_SRS_NAME => yx
+    case _ => yx
+  }
+
+  override lazy val value: Option[String] = {
+    (north ++ east ++ south++ west).headOption
+      .map(_ => s"($lower) ($upper)")
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
@@ -20,8 +20,9 @@ import scala.xml.Elem
 // TODO copied from easy-deposit-api
 //  which in turn was a (better isolated) variation of
 //  easy-split-multi-deposit/AddDatasetMetadataToDeposit
-//  dropped the trait OptionalValue from easy-deposit-api
-//  added an dcxGml field as that also is a common factor in all projects
+//  * dropped the trait OptionalValue from easy-deposit-api
+//  * added an dcxGml field as that also is a common factor in these 3 projects
+//    it won't be of use for DDM to dataverse-json
 
 object SpatialNames {
   /** coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X) */

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
@@ -61,14 +61,6 @@ case class SpatialPoint(scheme: Option[String],
     (x ++ y).headOption
       .map(_ => pos)
   }
-
-  lazy val xml: Option[Elem] = value.map(value =>
-    <dcx-gml:spatial srsName={ srsName }>
-      <Point xmlns="http://www.opengis.net/gml">
-        <pos>{ value }</pos>
-      </Point>
-    </dcx-gml:spatial>
-  )
 }
 
 case class SpatialBox(scheme: Option[String],
@@ -112,15 +104,4 @@ case class SpatialBox(scheme: Option[String],
     (north ++ east ++ south++ west).headOption
       .map(_ => s"($lower) ($upper)")
   }
-
-  lazy val xml: Option[Elem] = value.map(value =>
-    <dcx-gml:spatial>
-      <boundedBy xmlns="http://www.opengis.net/gml">
-          <Envelope srsName={ srsName }>
-              <lowerCorner>{ lower }</lowerCorner>
-              <upperCorner>{ upper }</upperCorner>
-          </Envelope>
-      </boundedBy>
-    </dcx-gml:spatial>
-  )
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Spatial.scala
@@ -21,7 +21,7 @@ import scala.xml.Elem
 //  which in turn was a (better isolated) variation of
 //  easy-split-multi-deposit/AddDatasetMetadataToDeposit
 //  dropped the trait OptionalValue from easy-deposit-api
-//  added an xml field as that also was a common factor in all projects
+//  added an dcxGml field as that also is a common factor in all projects
 
 object SpatialNames {
   /** coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X) */
@@ -61,6 +61,14 @@ case class SpatialPoint(scheme: Option[String],
     (x ++ y).headOption
       .map(_ => pos)
   }
+
+  lazy val dcxGml: Option[Elem] = value.map(value =>
+    <dcx-gml:spatial srsName={ srsName }>
+      <Point xmlns="http://www.opengis.net/gml">
+        <pos>{ value }</pos>
+      </Point>
+    </dcx-gml:spatial>
+  )
 }
 
 case class SpatialBox(scheme: Option[String],
@@ -101,7 +109,18 @@ case class SpatialBox(scheme: Option[String],
   }
 
   override lazy val value: Option[String] = {
-    (north ++ east ++ south++ west).headOption
+    (north ++ east ++ south ++ west).headOption
       .map(_ => s"($lower) ($upper)")
   }
+
+  lazy val dcxGml: Option[Elem] = value.map(_ =>
+    <dcx-gml:spatial>
+      <boundedBy xmlns="http://www.opengis.net/gml">
+          <Envelope srsName={ srsName }>
+              <lowerCorner>{ lower }</lowerCorner>
+              <upperCorner>{ upper }</upperCorner>
+          </Envelope>
+      </boundedBy>
+    </dcx-gml:spatial>
+  )
 }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.easy.fedora2vault.fixture.{ AudienceSupport, EmdSupport, Sch
 import nl.knaw.dans.pf.language.emd.EasyMetadataImpl
 import nl.knaw.dans.pf.language.emd.binding.EmdUnmarshaller
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Success, Try }
 import scala.xml.Utility.trim
 import scala.xml._
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
@@ -299,6 +299,208 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     )) // logging explains the not implemented
   }
 
+  it should "render a polygon" in {
+    val emd = parseEmdContent(Seq(
+      emdTitle, emdCreator, emdDescription, emdDates,
+        <emd:coverage>
+          <eas:spatial>
+            <eas:polygon eas:scheme="RD">
+              <eas:place>Some kind of description, without an actual polygon attached to it</eas:place>
+            </eas:polygon>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:polygon eas:scheme="degrees">
+              <eas:place>A triangle between DANS, NWO and the railway station</eas:place>
+              <eas:polygon-exterior>
+                <eas:place>main triangle</eas:place>
+                <eas:polygon-point><eas:x>52.08110</eas:x><eas:y>4.34521</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.08071</eas:x><eas:y>4.34422</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.07913</eas:x><eas:y>4.34332</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.08110</eas:x><eas:y>4.34521</eas:y></eas:polygon-point>
+              </eas:polygon-exterior>
+              <eas:polygon-interior>
+                <eas:place>hole1</eas:place>
+                <eas:polygon-point><eas:x>52.080542</eas:x><eas:y>4.344215</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.080450</eas:x><eas:y>4.344323</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.080357</eas:x><eas:y>4.344110</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.080542</eas:x><eas:y>4.344215</eas:y></eas:polygon-point>
+              </eas:polygon-interior>
+              <eas:polygon-interior>
+                <eas:place>hole2</eas:place>
+                <eas:polygon-point><eas:x>52.080542</eas:x><eas:y>4.344215</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.080450</eas:x><eas:y>4.344323</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.080357</eas:x><eas:y>4.344110</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>52.080542</eas:x><eas:y>4.344215</eas:y></eas:polygon-point>
+              </eas:polygon-interior>
+            </eas:polygon>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:polygon eas:scheme="RD">
+              <eas:place>A triangle between DANS, NWO and the railway station</eas:place>
+              <eas:polygon-interior>
+                <eas:place>hole in none</eas:place>
+                <eas:polygon-point><eas:x>83506</eas:x><eas:y>455210</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>83513</eas:x><eas:y>455200</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>83499</eas:x><eas:y>455189</eas:y></eas:polygon-point>
+                <eas:polygon-point><eas:x>83506</eas:x><eas:y>455210</eas:y></eas:polygon-point>
+              </eas:polygon-interior>
+            </eas:polygon>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:polygon eas:scheme="RD">
+              <eas:place>A triangle between DANS, NWO and the railway station</eas:place>
+              <eas:polygon-interior>
+                <eas:place>pointless hole</eas:place>
+              </eas:polygon-interior>
+            </eas:polygon>
+          </eas:spatial>
+        </emd:coverage>,
+      emdRights,
+    ))
+    val triedDDM = DDM(emd, Seq("D35400"))
+    triedDDM.map(normalized(_).replace("<posList></posList>", "<posList/>")) shouldBe Success(normalized(
+      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+           <dcx-gml:spatial>
+             <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
+               <description>Some kind of description, without an actual polygon attached to it</description>
+             </Polygon>
+           </dcx-gml:spatial>
+           <dcx-gml:spatial>
+             <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/4326" xmlns="http://www.opengis.net/gml">
+               <description>A triangle between DANS, NWO and the railway station</description>
+               <exterior><LinearRing><description>main triangle</description><posList>4.34521 52.08110 4.34422 52.08071 4.34332 52.07913 4.34521 52.08110</posList></LinearRing></exterior>
+               <interior><LinearRing><description>hole1</description><posList>4.344215 52.080542 4.344323 52.080450 4.344110 52.080357 4.344215 52.080542</posList></LinearRing></interior>
+               <interior><LinearRing><description>hole2</description><posList>4.344215 52.080542 4.344323 52.080450 4.344110 52.080357 4.344215 52.080542</posList></LinearRing></interior>
+             </Polygon>
+           </dcx-gml:spatial>
+           <dcx-gml:spatial>
+             <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
+               <description>A triangle between DANS, NWO and the railway station</description>
+               <interior><LinearRing><description>hole in none</description><posList>83506 455210 83513 455200 83499 455189 83506 455210</posList></LinearRing></interior>
+             </Polygon>
+           </dcx-gml:spatial>
+           <dcx-gml:spatial>
+             <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
+               <description>A triangle between DANS, NWO and the railway station</description>
+               <interior><LinearRing><description>pointless hole</description><posList></posList></LinearRing></interior>
+             </Polygon>
+           </dcx-gml:spatial>
+          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+    )) // Note that even te validation is happy with a pointless polygon or an interior without exterior
+    assume(schemaIsAvailable)
+    triedDDM.flatMap(validate) shouldBe Success(())
+  }
+
+  it should "render a box" in {
+    val emd = parseEmdContent(Seq(
+      emdTitle, emdCreator, emdDescription, emdDates,
+        <emd:coverage>
+          <eas:spatial>
+            <eas:box eas:scheme="RD">
+              <eas:north>455271.2</eas:north>
+              <eas:east>83575.4</eas:east>
+              <eas:south>455271.0</eas:south>
+              <eas:west>83575.0</eas:west>
+            </eas:box>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:box eas:scheme="degrees">
+              <eas:north>79.5</eas:north>
+              <eas:east>23.0</eas:east>
+              <eas:south>76.7</eas:south>
+              <eas:west>10.0</eas:west>
+            </eas:box>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:box eas:scheme="RD">
+              <eas:west>83575.0</eas:west>
+            </eas:box>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:box eas:scheme="degrees">
+                <eas:north>79.5</eas:north>
+            </eas:box>
+          </eas:spatial>
+        </emd:coverage>,
+      emdRights,
+    ))
+    val triedDDM = DDM(emd, Seq("D35400"))
+    triedDDM.map(normalized) shouldBe Success(normalized(
+      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+           <dcx-gml:spatial>
+             <boundedBy xmlns="http://www.opengis.net/gml">
+               <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+                 <lowerCorner>83575.0 455271.0</lowerCorner>
+                 <upperCorner>83575.4 455271.2</upperCorner>
+               </Envelope>
+             </boundedBy>
+           </dcx-gml:spatial>
+           <dcx-gml:spatial>
+             <boundedBy xmlns="http://www.opengis.net/gml">
+               <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                 <lowerCorner>76.7 10.0</lowerCorner>
+                 <upperCorner>79.5 23.0</upperCorner>
+               </Envelope>
+             </boundedBy>
+           </dcx-gml:spatial>
+           <dcx-gml:spatial>
+             <boundedBy xmlns="http://www.opengis.net/gml">
+               <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+                 <lowerCorner>83575.0 0</lowerCorner>
+                 <upperCorner>0 0</upperCorner>
+               </Envelope>
+             </boundedBy>
+           </dcx-gml:spatial>
+           <dcx-gml:spatial>
+             <boundedBy xmlns="http://www.opengis.net/gml">
+               <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                 <lowerCorner>0 0</lowerCorner>
+                 <upperCorner>79.5 0</upperCorner>
+               </Envelope>
+             </boundedBy>
+           </dcx-gml:spatial>
+           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+    ))
+    assume(schemaIsAvailable)
+    triedDDM.flatMap(validate) shouldBe Success(())
+  }
+
+  it should "complain about a box without any coordinate" in {
+    val emd = parseEmdContent(Seq(
+      emdTitle, emdCreator, emdDescription, emdDates,
+        <emd:coverage>
+          <eas:spatial>
+            <eas:box eas:scheme="RD">
+            </eas:box>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:box eas:scheme="degrees">
+            </eas:box>
+          </eas:spatial>
+        </emd:coverage>,
+      emdRights,
+    ))
+    val triedDDM = DDM(emd, Seq("D35400"))
+    triedDDM.map(normalized) shouldBe Success(normalized(
+      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+          <not:implemented/>
+          <not:implemented/>
+          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+    )) // logging explains the not implemented
+  }
+
   "subject" should "succeed" in {
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator,

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
@@ -290,9 +290,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
-          <dcx-gml:spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
-            <not:implemented/>
-          </dcx-gml:spatial>
+          <not:implemented/>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>
@@ -493,90 +491,48 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
-          <dcx-gml:spatial>
-            <not:implemented/>
-          </dcx-gml:spatial>
-          <dcx-gml:spatial>
-            <not:implemented/>
-          </dcx-gml:spatial>
+          <not:implemented/>
+          <not:implemented/>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>
     )) // logging explains the not implemented
   }
 
-  it should "render a mix of spatial element types" in {
+  it should "report a mix of spatial element types" in {
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator, emdDescription, emdDates,
         <emd:coverage>
           <eas:spatial>
             <eas:place>A general description</eas:place>
+          </eas:spatial>
+          <eas:spatial>
             <eas:point><eas:x>1</eas:x></eas:point>
             <eas:box eas:scheme="degrees"><eas:north>79.5</eas:north><eas:east>23.0</eas:east><eas:south>76.7</eas:south><eas:west>10.0</eas:west></eas:box>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:box eas:scheme="degrees"><eas:north>79.5</eas:north><eas:east>23.0</eas:east><eas:south>76.7</eas:south><eas:west>10.0</eas:west></eas:box>
+            <eas:polygon eas:scheme="RD"><eas:place>A polygon description</eas:place></eas:polygon>
+          </eas:spatial>
+          <eas:spatial>
+            <eas:point><eas:x>1</eas:x></eas:point>
             <eas:polygon eas:scheme="RD"><eas:place>A polygon description</eas:place></eas:polygon>
           </eas:spatial>
         </emd:coverage>,
       emdRights,
     ))
-    val triedDDM = DDM(emd, Seq("D35400"))
-    triedDDM.map(normalized) shouldBe Success(normalized(
+    DDM(emd, Seq("D35400")).map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
-          <dcx-gml:spatial>
-            <name>A general description</name>
-            <Point xmlns="http://www.opengis.net/gml"><pos>0 1</pos></Point>
-            <boundedBy xmlns="http://www.opengis.net/gml">
-              <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                <lowerCorner>76.7 10.0</lowerCorner>
-                <upperCorner>79.5 23.0</upperCorner>
-              </Envelope>
-            </boundedBy>
-            <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
-              <name>A polygon description</name>
-            </Polygon>
-          </dcx-gml:spatial>
+          <not:implemented/>
+          <not:implemented/>
+          <not:implemented/>
+          <not:implemented/>
           <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
         </ddm:dcmiMetadata>
       </ddm:DDM>
     ))
-    assume(schemaIsAvailable)
-    triedDDM.flatMap(validate) should matchPattern {
-      case Failure(e: SAXParseException) if e.getLocalizedMessage
-        .matches(".*Invalid content was found starting with element 'name'. One of .*:_Geometry, .*:boundedBy}' is expected.") =>
-    }
-
-    // other rendering variants found elsewhere in the EASY code base
-
-    validate( // easy-ddm/src/test/resources/input/spatial.xml
-      <ddm:DDM xsi:schemaLocation={ schemaLocation } xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        { ddmProfile("D35400") }
-        <ddm:dcmiMetadata>
-          <dcx-gml:spatial>
-            <Point xmlns="http://www.opengis.net/gml">
-              <description>Entrance of DANS Building</description>
-              <name>Data Archiving and Networked Services (DANS)</name>
-              <pos>52.08110 4.34521 1.12</pos>
-            </Point>
-          </dcx-gml:spatial>
-          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
-        </ddm:dcmiMetadata>
-      </ddm:DDM>
-    ) shouldBe a[Success[_]]
-
-    validate( // easy-app/front-end/easy-sword/src/test/resources/input/demoDDM.xml
-      <ddm:DDM xsi:schemaLocation={ schemaLocation } xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        { ddmProfile("D35400") }
-        <ddm:dcmiMetadata>
-          <dct:spatial xsi:type="dcx-gml:SimpleGMLType">
-            <Point xmlns="http://www.opengis.net/gml">
-              <pos>1.0 2.0</pos>
-            </Point>
-          </dct:spatial>
-          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
-        </ddm:dcmiMetadata>
-      </ddm:DDM>
-    ) shouldBe a[Success[_]]
   }
 
   "subject" should "succeed" in {

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
@@ -278,7 +278,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     triedDDM.flatMap(validate) shouldBe Success(())
   }
 
-  it should "report a point without coordinates" in {
+  it should "report a point without coordinates as not implemented" in {
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator, emdDescription, emdDates,
         <emd:coverage>
@@ -286,8 +286,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
         </emd:coverage>,
       emdRights,
     ))
-    val triedDDM = DDM(emd, Seq("D35400"))
-    triedDDM.map(normalized) shouldBe Success(normalized(
+    DDM(emd, Seq("D35400")).map(normalized) shouldBe Success(normalized(
       <ddm:DDM xsi:schemaLocation={ schemaLocation }>
         { ddmProfile("D35400") }
         <ddm:dcmiMetadata>
@@ -298,55 +297,6 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
         </ddm:dcmiMetadata>
       </ddm:DDM>
     )) // logging explains the not implemented
-  }
-
-  it should "render a mix of spatial element types" in {
-    // TODO easy-schema-examples also has DDM with:
-    //  <dcterms:spatial xsi:type="dcx-gml:SimpleGMLType"><Point>
-    // TODO easy-sword test/demo also has DDM:
-      <Point xmlns="http://www.opengis.net/gml">
-        <description>Entrance of DANS Building</description>
-        <name>Data Archiving and Networked Services (DANS)</name>
-        <pos>52.08110 4.34521 1.12</pos>
-      </Point>
-
-    val emd = parseEmdContent(Seq(
-      emdTitle, emdCreator, emdDescription, emdDates,
-        <emd:coverage>
-          <eas:spatial>
-            <eas:place>A general description</eas:place>
-            <eas:point><eas:x>1</eas:x></eas:point>
-            <eas:box eas:scheme="degrees"><eas:north>79.5</eas:north><eas:east>23.0</eas:east><eas:south>76.7</eas:south><eas:west>10.0</eas:west></eas:box>
-            <eas:polygon eas:scheme="RD"><eas:place>A polygon description</eas:place></eas:polygon>
-          </eas:spatial>
-        </emd:coverage>,
-      emdRights,
-    ))
-    val triedDDM = DDM(emd, Seq("D35400"))
-    triedDDM.map(normalized) shouldBe Success(normalized(
-      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
-        { ddmProfile("D35400") }
-        <ddm:dcmiMetadata>
-          <dcx-gml:spatial>
-            <description>A general description</description>
-            <Point xmlns="http://www.opengis.net/gml"><pos>0 1</pos></Point>
-            <boundedBy xmlns="http://www.opengis.net/gml">
-              <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                <lowerCorner>76.7 10.0</lowerCorner>
-                <upperCorner>79.5 23.0</upperCorner>
-              </Envelope>
-            </boundedBy>
-            <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
-              <description>A polygon description</description>
-            </Polygon>
-          </dcx-gml:spatial>
-          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
-        </ddm:dcmiMetadata>
-      </ddm:DDM>
-    ))
-    assume(schemaIsAvailable)
-    triedDDM.foreach(x => println(printer.format(x)))
-    triedDDM.flatMap(validate) shouldBe a[Failure[_]]
   }
 
   it should "render a polygon" in {
@@ -414,12 +364,12 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
         <ddm:dcmiMetadata>
            <dcx-gml:spatial>
              <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
-               <description>Some kind of description, without an actual polygon attached to it</description>
+               <name>Some kind of description, without an actual polygon attached to it</name>
              </Polygon>
            </dcx-gml:spatial>
            <dcx-gml:spatial>
              <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/4326" xmlns="http://www.opengis.net/gml">
-               <description>A triangle between DANS, NWO and the railway station</description>
+               <name>A triangle between DANS, NWO and the railway station</name>
                <exterior><LinearRing><description>main triangle</description><posList>4.34521 52.08110 4.34422 52.08071 4.34332 52.07913 4.34521 52.08110</posList></LinearRing></exterior>
                <interior><LinearRing><description>hole1</description><posList>4.344215 52.080542 4.344323 52.080450 4.344110 52.080357 4.344215 52.080542</posList></LinearRing></interior>
                <interior><LinearRing><description>hole2</description><posList>4.344215 52.080542 4.344323 52.080450 4.344110 52.080357 4.344215 52.080542</posList></LinearRing></interior>
@@ -427,13 +377,13 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
            </dcx-gml:spatial>
            <dcx-gml:spatial>
              <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
-               <description>A triangle between DANS, NWO and the railway station</description>
+               <name>A triangle between DANS, NWO and the railway station</name>
                <interior><LinearRing><description>hole in none</description><posList>83506 455210 83513 455200 83499 455189 83506 455210</posList></LinearRing></interior>
              </Polygon>
            </dcx-gml:spatial>
            <dcx-gml:spatial>
              <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
-               <description>A triangle between DANS, NWO and the railway station</description>
+               <name>A triangle between DANS, NWO and the railway station</name>
                <interior><LinearRing><description>pointless hole</description><posList></posList></LinearRing></interior>
              </Polygon>
            </dcx-gml:spatial>
@@ -523,7 +473,7 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
     triedDDM.flatMap(validate) shouldBe Success(())
   }
 
-  it should "complain about a box without any coordinate" in {
+  it should "report a box without any coordinate as not implemented" in {
     val emd = parseEmdContent(Seq(
       emdTitle, emdCreator, emdDescription, emdDates,
         <emd:coverage>
@@ -553,6 +503,80 @@ class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport wi
         </ddm:dcmiMetadata>
       </ddm:DDM>
     )) // logging explains the not implemented
+  }
+
+  it should "render a mix of spatial element types" in {
+    val emd = parseEmdContent(Seq(
+      emdTitle, emdCreator, emdDescription, emdDates,
+        <emd:coverage>
+          <eas:spatial>
+            <eas:place>A general description</eas:place>
+            <eas:point><eas:x>1</eas:x></eas:point>
+            <eas:box eas:scheme="degrees"><eas:north>79.5</eas:north><eas:east>23.0</eas:east><eas:south>76.7</eas:south><eas:west>10.0</eas:west></eas:box>
+            <eas:polygon eas:scheme="RD"><eas:place>A polygon description</eas:place></eas:polygon>
+          </eas:spatial>
+        </emd:coverage>,
+      emdRights,
+    ))
+    val triedDDM = DDM(emd, Seq("D35400"))
+    triedDDM.map(normalized) shouldBe Success(normalized(
+      <ddm:DDM xsi:schemaLocation={ schemaLocation }>
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+          <dcx-gml:spatial>
+            <name>A general description</name>
+            <Point xmlns="http://www.opengis.net/gml"><pos>0 1</pos></Point>
+            <boundedBy xmlns="http://www.opengis.net/gml">
+              <Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                <lowerCorner>76.7 10.0</lowerCorner>
+                <upperCorner>79.5 23.0</upperCorner>
+              </Envelope>
+            </boundedBy>
+            <Polygon srsName="http://www.opengis.net/def/crs/EPSG/0/28992" xmlns="http://www.opengis.net/gml">
+              <name>A polygon description</name>
+            </Polygon>
+          </dcx-gml:spatial>
+          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+    ))
+    assume(schemaIsAvailable)
+    triedDDM.flatMap(validate) should matchPattern {
+      case Failure(e: SAXParseException) if e.getLocalizedMessage
+        .matches(".*Invalid content was found starting with element 'name'. One of .*:_Geometry, .*:boundedBy}' is expected.") =>
+    }
+
+    // other rendering variants found elsewhere in the EASY code base
+
+    validate( // easy-ddm/src/test/resources/input/spatial.xml
+      <ddm:DDM xsi:schemaLocation={ schemaLocation } xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+          <dcx-gml:spatial>
+            <Point xmlns="http://www.opengis.net/gml">
+              <description>Entrance of DANS Building</description>
+              <name>Data Archiving and Networked Services (DANS)</name>
+              <pos>52.08110 4.34521 1.12</pos>
+            </Point>
+          </dcx-gml:spatial>
+          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+    ) shouldBe a[Success[_]]
+
+    validate( // easy-app/front-end/easy-sword/src/test/resources/input/demoDDM.xml
+      <ddm:DDM xsi:schemaLocation={ schemaLocation } xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/" xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/" xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        { ddmProfile("D35400") }
+        <ddm:dcmiMetadata>
+          <dct:spatial xsi:type="dcx-gml:SimpleGMLType">
+            <Point xmlns="http://www.opengis.net/gml">
+              <pos>1.0 2.0</pos>
+            </Point>
+          </dct:spatial>
+          <dct:license xsi:type="dct:URI">{ DDM.cc0 }</dct:license>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+    ) shouldBe a[Success[_]]
   }
 
   "subject" should "succeed" in {


### PR DESCRIPTION
Fixes EASY-2744: EMD -> DDM spatial fields

#### When applied it will...
* [x] implement `emd.getEmdCoverage.getEasSpatial`
* [x] do thespatial components exclude one another or can one EMD element have a place and a box and...?
  We assume not, report as not implemented when practice proofs otherwise.
* [x] unit tests

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
