### PR TITLE
DD-112: specify command line interface for SIPs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,33 +11,33 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Tool for exporting datasets from Fedora and constructing Information Packages.
-Depending on the transformation type these packages are AIPs or SIPs: Archival or Submission Information Packages.
-An AIP is a [DANS-V0 bag], A SIP is a directory with a bag and a `deposit.properties` file.
+Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages.
+An AIP is a [DANS-V0 bag], a SIP is a directory with a bag and a `deposit.properties` file.
 
 [DANS-V0 bag]: https://github.com/DANS-KNAW/dans-bagit-profile/blob/master/docs/versions/0.0.0.md#dans-bagit-profile-v0
 
 ARGUMENTS
 ---------
 
-     -d, --datasetId  <arg>    A single easy-dataset-id to be transformed. Use either this or the input-file
-                               argument
-     -u, --depositor  <arg>    The depositor for these datasets. If provided, only datasets from this depositor
-                               are transformed.
-     -i, --input-file  <arg>   File containing a newline-separated list of easy-dataset-ids to be transformed.
-                               Use either this or the dataset-id argument
-     -l, --log-file  <arg>     The name of the logfile in csv format. If not provided a file
-                               easy-fedora2vault-<timestamp>.csv will be created in the home-dir of the user.
-                               (default = /home/vagrant/easy-fedora2vault-2020-02-02T20:20:02.000Z.csv)
-     -o, --output-dir  <arg>   Empty directory in which to stage the created IPs. It will be created if it
-                               doesn't exist.
-     -s, --strict              If provided, the transformation will check whether the datasets adhere to the
-                               requirements of the chosen transformation.
-     -h, --help                Show help message
-     -v, --version             Show version of this program
-
+     -d, --datasetId  <arg>       A single easy-dataset-id to be transformed. Use either this or the input-file
+                                  argument
+     -u, --depositor  <arg>       The depositor for these datasets. If provided, only datasets from this
+                                  depositor are transformed.
+     -i, --input-file  <arg>      File containing a newline-separated list of easy-dataset-ids to be transformed.
+                                  Use either this or the dataset-id argument
+     -l, --log-file  <arg>        The name of the logfile in csv format. If not provided a file
+                                  easy-fedora2vault-<timestamp>.csv will be created in the home-dir of the user.
+                                  (default = /home/vagrant/easy-fedora2vault-2020-02-02T20:20:02.000Z.csv)
+     -o, --output-dir  <arg>      Empty directory in which to stage the created IPs. It will be created if it
+                                  doesn't exist.
+     -f, --output-format  <arg>   Output format: AIP, SIP. Only required for transformation type simple.
+     -s, --strict                 If provided, the transformation will check whether the datasets adhere to the
+                                  requirements of the chosen transformation.
+     -h, --help                   Show help message
+     -v, --version                Show version of this program
+    
     trailing arguments:
-     transformation (required)   The type of transformation used: simple-AIP, simple-SIP, thematische-collectie.
+     transformation (required)   The type of transformation used: simple, thematische-collectie.
 
 EXAMPLES
 --------

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,11 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Tool for exporting datasets from Fedora and constructing AIP-bags to be stored in the bag stores
+Tool for exporting datasets from Fedora and constructing Information Packages.
+Depending on the transformation type these packages are AIPs or SIPs: Archival or Submission Information Packages.
+An AIP is a [DANS-V0 bag], A SIP is a directory with a bag and a `deposit.properties` file.
+
+[DANS-V0 bag]: https://github.com/DANS-KNAW/dans-bagit-profile/blob/master/docs/versions/0.0.0.md#dans-bagit-profile-v0
 
 ARGUMENTS
 ---------
@@ -25,7 +29,7 @@ ARGUMENTS
      -l, --log-file  <arg>     The name of the logfile in csv format. If not provided a file
                                easy-fedora2vault-<timestamp>.csv will be created in the home-dir of the user.
                                (default = /home/vagrant/easy-fedora2vault-2020-02-02T20:20:02.000Z.csv)
-     -o, --output-dir  <arg>   Empty directory in which to stage the created AIP bags. It will be created if it
+     -o, --output-dir  <arg>   Empty directory in which to stage the created IPs. It will be created if it
                                doesn't exist.
      -s, --strict              If provided, the transformation will check whether the datasets adhere to the
                                requirements of the chosen transformation.
@@ -33,7 +37,7 @@ ARGUMENTS
      -v, --version             Show version of this program
 
     trailing arguments:
-      transformation (required)   The type of transformation used. Possible values: simple, thematische-collectie.
+     transformation (required)   The type of transformation used: simple-AIP, simple-SIP, thematische-collectie.
 
 EXAMPLES
 --------

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version>1.0.2-SNAPSHOT</version>
 
     <name>EASY Fedora2vault</name>
-    <description>Tool for exporting datasets from Fedora and constructing Information Packages.</description>
+    <description>Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages.</description>
     <url>https://github.com/DANS-KNAW/easy-fedora2vault</url>
     <inceptionYear>2020</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version>1.0.2-SNAPSHOT</version>
 
     <name>EASY Fedora2vault</name>
-    <description>Tool for exporting datasets from Fedora and constructing AIP-bags to be stored in the bag stores</description>
+    <description>Tool for exporting datasets from Fedora and constructing Information Packages.</description>
     <url>https://github.com/DANS-KNAW/easy-fedora2vault</url>
     <inceptionYear>2020</inceptionYear>
 

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,9 +1,17 @@
+# required to check if the bag is already in the vault
 bag-index.url=http://localhost:20120/
 
+# source of the datasets
 fcrepo.url=http://localhost:8080/fedora
 fcrepo.user=fedoraAdmin
 fcrepo.password=changeme
 
+# required for user details in agreement documents
+# created from dataset foXml (dataset owner + EMD)
 auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
+
+# directory were a SIP is created,
+# once completed the SIP will be moved to the specified output-dir
+staging.dir=/var/opt/dans.knaw.nl/tmp/easy-fedora2vault/staged

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -52,13 +52,19 @@ object Command extends App with DebugEnhancedLogging {
     lazy val outputDir = commandLine.outputDir()
 
     (commandLine.transformation(), commandLine.outputFormat()) match {
+      case (SIMPLE, AIP) if commandLine.strictMode() =>
+        // TODO we would need a TargetIndex trait with BagIndex and DataverseIndex as implementations
+        Failure(new NotImplementedError(s"strict mode for SIPs would exclude datasets in the vault for dataverse"))
       case (SIMPLE, AIP) =>
-        // TODO construct a SIP in a staging directory, on success move to outputDir
+        // TODO construct SIPs in a staging directory, move completed SIPs to outputDir,
         Failure(new NotImplementedError(s"simple SIP is not implemented"))
       case (SIMPLE, SIP) => app
-        .simpleTransForms(ids, outputDir, strict, writer)(SimpleChecker(app.bagIndex))
-      case (THEMA, _) => app
-        .simpleTransForms(ids, outputDir, strict, writer)(ThemaChecker(app.bagIndex))
+        .simpleTransForms(ids, outputDir, strict, writer)(new SimpleChecker(app.bagIndex))
+      case (THEMA, SIP) => app
+        .simpleTransForms(ids, outputDir, strict, writer)(new ThemaChecker(app.bagIndex))
+      case (THEMA, _) =>
+        Failure(new NotImplementedError(s"Only AIPs for 'theamtische collecties'"))
+
     }
   }.map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.fedora2vault
 
 import better.files.File
+import nl.knaw.dans.easy.fedora2vault.OutputFormat._
 import nl.knaw.dans.easy.fedora2vault.TransformationType._
 import nl.knaw.dans.easy.fedora2vault.check._
 import nl.knaw.dans.lib.error._
@@ -50,13 +51,13 @@ object Command extends App with DebugEnhancedLogging {
     lazy val writer = commandLine.logFile().newFileWriter(append = true)
     lazy val outputDir = commandLine.outputDir()
 
-    commandLine.transformation() match {
-      case SIMPLE_SIP =>
+    (commandLine.transformation(), commandLine.outputFormat()) match {
+      case (SIMPLE, AIP) =>
         // TODO construct a SIP in a staging directory, on success move to outputDir
-        Failure(new NotImplementedError(s"transformation type $SIMPLE_SIP is not implemented"))
-      case SIMPLE_AIP => app
+        Failure(new NotImplementedError(s"simple SIP is not implemented"))
+      case (SIMPLE, SIP) => app
         .simpleTransForms(ids, outputDir, strict, writer)(SimpleChecker(app.bagIndex))
-      case THEMA => app
+      case (THEMA, _) => app
         .simpleTransForms(ids, outputDir, strict, writer)(ThemaChecker(app.bagIndex))
     }
   }.map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -28,7 +28,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   editBuilder(_.setHelpWidth(110))
   printedName = "easy-fedora2vault"
   version(configuration.version)
-  val description: String = s"""Tool for exporting datasets from Fedora and constructing AIP-bags to be stored in the bag stores"""
+  val description: String = s"""Tool for exporting datasets from Fedora and constructing Information Packages."""
   val synopsis: String =
     s"""
        |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
@@ -54,7 +54,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     descr = "File containing a newline-separated list of easy-dataset-ids to be transformed. Use either this or the dataset-id argument")
   val inputFile: ScallopOption[File] = inputPath.map(File(_))
   private val outputDirPath: ScallopOption[Path] = opt(name = "output-dir", short = 'o', required = true,
-    descr = "Empty directory in which to stage the created AIP bags. It will be created if it doesn't exist.")
+    descr = "Empty directory in which to stage the created IPs. It will be created if it doesn't exist.")
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
   val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',
     descr = "The depositor for these datasets. If provided, only datasets from this depositor are transformed.")
@@ -65,7 +65,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val strictMode: ScallopOption[Boolean] = opt(name = "strict", short = 's',
     descr = "If provided, the transformation will check whether the datasets adhere to the requirements of the chosen transformation.")
   val transformation: ScallopOption[TransformationType] = trailArg(name = "transformation",
-    descr = s"The type of transformation used. Possible values: ${ TransformationType.values.mkString(", ") }.")
+    descr = TransformationType.values.mkString("The type of transformation used: ",", ","."))
 
   requireOne(datasetId, inputPath)
 

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -19,6 +19,7 @@ import java.nio.file.{ Path, Paths }
 
 import better.files.File
 import nl.knaw.dans.easy.fedora2vault.TransformationType.TransformationType
+import nl.knaw.dans.easy.fedora2vault.OutputFormat.OutputFormat
 import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter, singleArgConverter }
 
 import scala.xml.Properties
@@ -28,7 +29,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   editBuilder(_.setHelpWidth(110))
   printedName = "easy-fedora2vault"
   version(configuration.version)
-  val description: String = s"""Tool for exporting datasets from Fedora and constructing Information Packages."""
+  val description: String = s"""Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages."""
   val synopsis: String =
     s"""
        |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
@@ -47,6 +48,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |""".stripMargin)
 
   implicit val transformationTypeConverter: ValueConverter[TransformationType] = singleArgConverter(TransformationType.withName)
+  implicit val outputFormatConverter: ValueConverter[OutputFormat] = singleArgConverter(OutputFormat.withName)
 
   val datasetId: ScallopOption[DatasetId] = opt(name = "datasetId", short = 'd',
     descr = "A single easy-dataset-id to be transformed. Use either this or the input-file argument")
@@ -56,6 +58,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   private val outputDirPath: ScallopOption[Path] = opt(name = "output-dir", short = 'o', required = true,
     descr = "Empty directory in which to stage the created IPs. It will be created if it doesn't exist.")
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
+  val outputFormat: ScallopOption[OutputFormat] = opt(name = "output-format", short = 'f',
+    descr = OutputFormat.values.mkString("Output format: ",", ",". Only required for transformation type simple."))
   val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',
     descr = "The depositor for these datasets. If provided, only datasets from this depositor are transformed.")
   private val logFilePath: ScallopOption[Path] = opt(name = "log-file", short = 'l',

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Configuration.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Configuration.scala
@@ -27,6 +27,7 @@ case class Configuration(version: String,
                          fedoraCredentials: FedoraCredentials,
                          ldapEnv: LdapEnv,
                          bagIndexUrl: URI,
+                         stagingDir: File,
                         )
 
 object Configuration {
@@ -57,6 +58,7 @@ object Configuration {
         put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
       },
       new URI(properties.getString("bag-index.url")),
+      File(properties.getString("staging.dir")),
     )
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -70,7 +70,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       case t: FedoraClientException if t.getStatus != 404 => Failure(t)
       case t: Exception if t.isInstanceOf[IOException] => Failure(t)
       case t => Success(CsvRecord(
-        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE_AIP.toString, s"FAILED: $t"
+        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE.toString, s"FAILED: $t"
       ))
     }
       .doIfSuccess(_.print(printer))
@@ -136,7 +136,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       UUID.fromString(bagDir.name),
       doi,
       depositor,
-      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse(SIMPLE_AIP.toString),
+      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse(SIMPLE.toString),
       maybeTransformationViolations.getOrElse("OK"),
     )
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -30,7 +30,7 @@ import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.fedora2vault.Command.FeedBackMessage
 import nl.knaw.dans.easy.fedora2vault.FileItem.{ checkNotImplemented, filesXml }
 import nl.knaw.dans.easy.fedora2vault.FoXml.{ getEmd, _ }
-import nl.knaw.dans.easy.fedora2vault.TransformationType.SIMPLE
+import nl.knaw.dans.easy.fedora2vault.TransformationType._
 import nl.knaw.dans.easy.fedora2vault.check._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -70,7 +70,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       case t: FedoraClientException if t.getStatus != 404 => Failure(t)
       case t: Exception if t.isInstanceOf[IOException] => Failure(t)
       case t => Success(CsvRecord(
-        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE.toString, s"FAILED: $t"
+        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE_AIP.toString, s"FAILED: $t"
       ))
     }
       .doIfSuccess(_.print(printer))
@@ -136,7 +136,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       UUID.fromString(bagDir.name),
       doi,
       depositor,
-      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse("simple"),
+      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse(SIMPLE_AIP.toString),
       maybeTransformationViolations.getOrElse("OK"),
     )
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/OutputFormat.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/OutputFormat.scala
@@ -15,11 +15,11 @@
  */
 package nl.knaw.dans.easy.fedora2vault
 
-object TransformationType extends Enumeration {
-  type TransformationType = Value
+object OutputFormat extends Enumeration {
+  type OutputFormat = Value
 
   // @formatter:off
-  val SIMPLE: TransformationType = Value("simple")
-  val THEMA: TransformationType = Value("thematische-collectie")
+  val AIP: OutputFormat = Value("AIP")
+  val SIP: OutputFormat = Value("SIP")
   // @formatter:on
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/TransformationType.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/TransformationType.scala
@@ -19,7 +19,8 @@ object TransformationType extends Enumeration {
   type TransformationType = Value
 
   // @formatter:off
-  val SIMPLE: TransformationType = Value("simple")
+  val SIMPLE_AIP: TransformationType = Value("simple-AIP")
+  val SIMPLE_SIP: TransformationType = Value("simple-SIP")
   val THEMA: TransformationType = Value("thematische-collectie")
   // @formatter:on
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/SimpleChecker.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/SimpleChecker.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.fedora2vault.check
 
 import nl.knaw.dans.easy.fedora2vault.BagIndex
 
-case class SimpleChecker(override val bagIndex: BagIndex) extends TransformationChecker {
+class SimpleChecker(override val bagIndex: BagIndex) extends TransformationChecker {
   override def forbiddenTitle(title: String): Boolean = {
     title.toLowerCase.contains("thematische collectie")
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/ThemaChecker.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/ThemaChecker.scala
@@ -17,8 +17,6 @@ package nl.knaw.dans.easy.fedora2vault.check
 
 import nl.knaw.dans.easy.fedora2vault.BagIndex
 
-case class ThemaChecker(override val bagIndex: BagIndex) extends TransformationChecker {
-  override def forbiddenTitle(title: String): Boolean = {
-    !title.toLowerCase.contains("thematische collectie")
-  }
+class ThemaChecker(override val bagIndex: BagIndex) extends SimpleChecker(bagIndex) {
+  override def forbiddenTitle(title: String): Boolean = !super.forbiddenTitle(title)
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -7,3 +7,5 @@ fcrepo.password=fedoraAdmin
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
+
+staging.dir=/var/opt/dans.knaw.nl/tmp/easy-fedora2vault/staged

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -47,7 +47,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     override lazy val fedoraProvider: FedoraProvider = mock[FedoraProvider]
     override lazy val ldapContext: InitialLdapContext = mock[MockedLdapContext]
     override lazy val bagIndex: BagIndex = mockedBagIndex
-    val simpleChecker: SimpleChecker = SimpleChecker(bagIndex)
+    val simpleChecker: SimpleChecker = new SimpleChecker(bagIndex)
   }
 
   private class OverriddenApp extends MockedApp {

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -96,8 +96,8 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     sw.toString should (fullyMatch regex
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK
-        |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
-        |notSimple:3,.*,,,simple,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
+        |failure:2,.*,,,simple-AIP,FAILED: java.lang.Exception: failure:2
+        |notSimple:3,.*,,,simple-AIP,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
         |success:4,.*,,,simple,OK
         |""".stripMargin
       )
@@ -117,7 +117,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
+      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
     (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
@@ -180,7 +180,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
+      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -96,8 +96,8 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     sw.toString should (fullyMatch regex
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK
-        |failure:2,.*,,,simple-AIP,FAILED: java.lang.Exception: failure:2
-        |notSimple:3,.*,,,simple-AIP,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
+        |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
+        |notSimple:3,.*,,,simple,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
         |success:4,.*,,,simple,OK
         |""".stripMargin
       )
@@ -117,7 +117,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
+      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
     (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
@@ -180,7 +180,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
+      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
@@ -24,6 +24,7 @@ import scala.util.{ Failure, Success, Try }
 import scala.xml._
 
 class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport with SchemaSupport {
+  System.setProperty("http.agent", "Test")
 
   override val schema = "https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd"
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/ReadmeSpec.scala
@@ -29,6 +29,7 @@ class ReadmeSpec extends TestSupportFixture with CustomMatchers with FixedCurren
     fedoraCredentials = null,
     ldapEnv = null,
     bagIndexUrl = null,
+    stagingDir = null,
   )
   Properties.setProp("user.home", "/home/vagrant")
   private val clo = new CommandLineOptions(Array[String](), configuration) {


### PR DESCRIPTION
Fixes DD-112: specify command line interface for SIPs

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/DataverseDANS start?
* [ ] code changes specify the command line changes, still a draft with some review comments to discus.
* [ ] to keep everything together for now, below the specs for the `deposit.properties`,
  for any `.*` in the first column refer to the specs for [easy-inest-flow](https://github.com/DANS-KNAW/easy-specs/blob/master/deposit-directory/deposit-directory.md#depositproperties)


Property                      | Format                               | Description
------------------------------|--------------------------------------|-------------------------------------
`creation.timestamp`          | ISO 8601 datetime, including timezone and in ms precision | The moment this deposit was created.
`state.label`                 | A state label (see below)            | depends on the implementation of `dd-dans-deposit-to-dataverse`
`state.description`           | Text                                 | idem
`depositor.userId`            | EASY User Account ID                 | The EASY account of the dataset owner.
`deposit.ingest.current-step` | Last active step in ingest-flow      | depends on the implementation of `dd-dans-deposit-to-dataverse`
`deposit.origin`              | Deposit method                       | `fedora`, the future name of `easy-fedora2vault` or whatever specified by `dd-dans-deposit-to-dataverse`
`identifier.doi`              | DOI                                  | A DOI for the dataset. Use the prefix to identify the registrant.
`identifier.dans-doi.registered` | `yes` or `no`                     | ???
`identifier.dans-doi.action`  | `update` or `create`                 | depends on the implementation of `dd-dans-deposit-to-dataverse`
`identifier.fedora`           | easy-dataset:id in Fedora            | The Fedora Identifier in EASY-Fedora.
`identifier.urn`              | URN-NBN                              | A DANS minted `Uniform Resource Name` used to identify the dataset
`bag-store.*`            |                                  | not apliccable
`curation.*` |                  | depends on the implementation of `dd-dans-deposit-to-dataverse`
`springfield.*`          |                                 | not applicable?

