### PR TITLE
DD-112: enable deposit-dir export

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,33 +11,33 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Tool for exporting datasets from Fedora and constructing Information Packages.
-Depending on the transformation type these packages are AIPs or SIPs: Archival or Submission Information Packages.
-An AIP is a [DANS-V0 bag], A SIP is a directory with a bag and a `deposit.properties` file.
+Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages.
+An AIP is a [DANS-V0 bag], a SIP is a directory with a bag and a `deposit.properties` file.
 
 [DANS-V0 bag]: https://github.com/DANS-KNAW/dans-bagit-profile/blob/master/docs/versions/0.0.0.md#dans-bagit-profile-v0
 
 ARGUMENTS
 ---------
 
-     -d, --datasetId  <arg>    A single easy-dataset-id to be transformed. Use either this or the input-file
-                               argument
-     -u, --depositor  <arg>    The depositor for these datasets. If provided, only datasets from this depositor
-                               are transformed.
-     -i, --input-file  <arg>   File containing a newline-separated list of easy-dataset-ids to be transformed.
-                               Use either this or the dataset-id argument
-     -l, --log-file  <arg>     The name of the logfile in csv format. If not provided a file
-                               easy-fedora2vault-<timestamp>.csv will be created in the home-dir of the user.
-                               (default = /home/vagrant/easy-fedora2vault-2020-02-02T20:20:02.000Z.csv)
-     -o, --output-dir  <arg>   Empty directory in which to stage the created IPs. It will be created if it
-                               doesn't exist.
-     -s, --strict              If provided, the transformation will check whether the datasets adhere to the
-                               requirements of the chosen transformation.
-     -h, --help                Show help message
-     -v, --version             Show version of this program
-
+     -d, --datasetId  <arg>       A single easy-dataset-id to be transformed. Use either this or the input-file
+                                  argument
+     -u, --depositor  <arg>       The depositor for these datasets. If provided, only datasets from this
+                                  depositor are transformed.
+     -i, --input-file  <arg>      File containing a newline-separated list of easy-dataset-ids to be transformed.
+                                  Use either this or the dataset-id argument
+     -l, --log-file  <arg>        The name of the logfile in csv format. If not provided a file
+                                  easy-fedora2vault-<timestamp>.csv will be created in the home-dir of the user.
+                                  (default = /home/vagrant/easy-fedora2vault-2020-02-02T20:20:02.000Z.csv)
+     -o, --output-dir  <arg>      Empty directory in which to stage the created IPs. It will be created if it
+                                  doesn't exist.
+     -f, --output-format  <arg>   Output format: AIP, SIP. Only required for transformation type simple.
+     -s, --strict                 If provided, the transformation will check whether the datasets adhere to the
+                                  requirements of the chosen transformation.
+     -h, --help                   Show help message
+     -v, --version                Show version of this program
+    
     trailing arguments:
-     transformation (required)   The type of transformation used: simple-AIP, simple-SIP, thematische-collectie.
+     transformation (required)   The type of transformation used: simple, thematische-collectie.
 
 EXAMPLES
 --------

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Retrieves a dataset from Fedora and transforms it to an AIP bag conforming to DA
 SYNOPSIS
 --------
 
-    easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
+    easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} -o <staged-AIP-dir> [-s] [-l <log-file>] <transformation>
 
 DESCRIPTION
 -----------
@@ -21,8 +21,6 @@ ARGUMENTS
 
      -d, --datasetId  <arg>       A single easy-dataset-id to be transformed. Use either this or the input-file
                                   argument
-     -u, --depositor  <arg>       The depositor for these datasets. If provided, only datasets from this
-                                  depositor are transformed.
      -i, --input-file  <arg>      File containing a newline-separated list of easy-dataset-ids to be transformed.
                                   Use either this or the dataset-id argument
      -l, --log-file  <arg>        The name of the logfile in csv format. If not provided a file

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,11 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Tool for exporting datasets from Fedora and constructing AIP-bags to be stored in the bag stores
+Tool for exporting datasets from Fedora and constructing Information Packages.
+Depending on the transformation type these packages are AIPs or SIPs: Archival or Submission Information Packages.
+An AIP is a [DANS-V0 bag], A SIP is a directory with a bag and a `deposit.properties` file.
+
+[DANS-V0 bag]: https://github.com/DANS-KNAW/dans-bagit-profile/blob/master/docs/versions/0.0.0.md#dans-bagit-profile-v0
 
 ARGUMENTS
 ---------
@@ -25,7 +29,7 @@ ARGUMENTS
      -l, --log-file  <arg>     The name of the logfile in csv format. If not provided a file
                                easy-fedora2vault-<timestamp>.csv will be created in the home-dir of the user.
                                (default = /home/vagrant/easy-fedora2vault-2020-02-02T20:20:02.000Z.csv)
-     -o, --output-dir  <arg>   Empty directory in which to stage the created AIP bags. It will be created if it
+     -o, --output-dir  <arg>   Empty directory in which to stage the created IPs. It will be created if it
                                doesn't exist.
      -s, --strict              If provided, the transformation will check whether the datasets adhere to the
                                requirements of the chosen transformation.
@@ -33,7 +37,7 @@ ARGUMENTS
      -v, --version             Show version of this program
 
     trailing arguments:
-      transformation (required)   The type of transformation used. Possible values: simple, thematische-collectie.
+     transformation (required)   The type of transformation used: simple-AIP, simple-SIP, thematische-collectie.
 
 EXAMPLES
 --------

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version>1.0.2-SNAPSHOT</version>
 
     <name>EASY Fedora2vault</name>
-    <description>Tool for exporting datasets from Fedora and constructing Information Packages.</description>
+    <description>Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages.</description>
     <url>https://github.com/DANS-KNAW/easy-fedora2vault</url>
     <inceptionYear>2020</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version>1.0.2-SNAPSHOT</version>
 
     <name>EASY Fedora2vault</name>
-    <description>Tool for exporting datasets from Fedora and constructing AIP-bags to be stored in the bag stores</description>
+    <description>Tool for exporting datasets from Fedora and constructing Information Packages.</description>
     <url>https://github.com/DANS-KNAW/easy-fedora2vault</url>
     <inceptionYear>2020</inceptionYear>
 

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,9 +1,17 @@
+# required to check if the bag is already in the vault
 bag-index.url=http://localhost:20120/
 
+# source of the datasets
 fcrepo.url=http://localhost:8080/fedora
 fcrepo.user=fedoraAdmin
 fcrepo.password=changeme
 
+# required for user details in agreement documents
+# created from dataset foXml (dataset owner + EMD)
 auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
+
+# directory were a SIP is created,
+# once completed the SIP will be moved to the specified output-dir
+staging.dir=/var/opt/dans.knaw.nl/tmp/easy-fedora2vault/staged

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -55,9 +55,9 @@ object Command extends App with DebugEnhancedLogging {
       case (SIMPLE, SIP) =>
         printer.apply(app.simpleSips(ids, outputDir, strict, SimpleFilter()))
       case (SIMPLE, AIP) =>
-        printer.apply(app.simpleTransForms(ids, outputDir, strict, SimpleFilter(app.bagIndex)))
+        printer.apply(app.simpleAips(ids, outputDir, strict, SimpleFilter(app.bagIndex)))
       case (THEMA, AIP) =>
-        printer.apply(app.simpleTransForms(ids, outputDir, strict, ThemaFilter(app.bagIndex)))
+        printer.apply(app.simpleAips(ids, outputDir, strict, ThemaFilter(app.bagIndex)))
       case tuple =>
         Failure(new NotImplementedError(s"$tuple not implemented"))
     }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -52,13 +52,19 @@ object Command extends App with DebugEnhancedLogging {
     lazy val outputDir = commandLine.outputDir()
 
     (commandLine.transformation(), commandLine.outputFormat()) match {
+      case (SIMPLE, AIP) if commandLine.strictMode() =>
+        // TODO we would need a TargetIndex trait with BagIndex and DataverseIndex as implementations
+        Failure(new NotImplementedError(s"strict mode for SIPs would exclude datasets in the vault for dataverse"))
       case (SIMPLE, AIP) =>
-        // TODO construct a SIP in a staging directory, on success move to outputDir
+        // TODO construct SIPs in a staging directory, move completed SIPs to outputDir,
         Failure(new NotImplementedError(s"simple SIP is not implemented"))
       case (SIMPLE, SIP) => app
-        .simpleTransForms(ids, outputDir, strict, writer)(SimpleChecker(app.bagIndex))
-      case (THEMA, _) => app
-        .simpleTransForms(ids, outputDir, strict, writer)(ThemaChecker(app.bagIndex))
+        .simpleTransForms(ids, outputDir, strict, writer)(new SimpleChecker(app.bagIndex))
+      case (THEMA, SIP) => app
+        .simpleTransForms(ids, outputDir, strict, writer)(new ThemaChecker(app.bagIndex))
+      case (THEMA, _) =>
+        Failure(new NotImplementedError(s"Only AIPs for 'theamtische collecties'"))
+
     }
   }.map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.fedora2vault
 
-import better.files.{ Dispose, File }
+import better.files.File
 import nl.knaw.dans.easy.fedora2vault.OutputFormat._
 import nl.knaw.dans.easy.fedora2vault.TransformationType._
 import nl.knaw.dans.easy.fedora2vault.filter._

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.fedora2vault
 
 import better.files.File
+import nl.knaw.dans.easy.fedora2vault.OutputFormat._
 import nl.knaw.dans.easy.fedora2vault.TransformationType._
 import nl.knaw.dans.easy.fedora2vault.check._
 import nl.knaw.dans.lib.error._
@@ -50,13 +51,13 @@ object Command extends App with DebugEnhancedLogging {
     lazy val writer = commandLine.logFile().newFileWriter(append = true)
     lazy val outputDir = commandLine.outputDir()
 
-    commandLine.transformation() match {
-      case SIMPLE_SIP =>
+    (commandLine.transformation(), commandLine.outputFormat()) match {
+      case (SIMPLE, AIP) =>
         // TODO construct a SIP in a staging directory, on success move to outputDir
-        Failure(new NotImplementedError(s"transformation type $SIMPLE_SIP is not implemented"))
-      case SIMPLE_AIP => app
+        Failure(new NotImplementedError(s"simple SIP is not implemented"))
+      case (SIMPLE, SIP) => app
         .simpleTransForms(ids, outputDir, strict, writer)(SimpleChecker(app.bagIndex))
-      case THEMA => app
+      case (THEMA, _) => app
         .simpleTransForms(ids, outputDir, strict, writer)(ThemaChecker(app.bagIndex))
     }
   }.map(msg => s"$msg, for details see ${ commandLine.logFile().toJava.getAbsolutePath }")

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Command.scala
@@ -53,11 +53,11 @@ object Command extends App with DebugEnhancedLogging {
 
     (commandLine.transformation(), commandLine.outputFormat()) match {
       case (SIMPLE, SIP) =>
-        printer.apply(app.simpleSips(ids, outputDir, strict, SimpleFilter()))
+        printer.apply(app.createSips(ids, outputDir, strict, SimpleFilter()))
       case (SIMPLE, AIP) =>
-        printer.apply(app.simpleAips(ids, outputDir, strict, SimpleFilter(app.bagIndex)))
+        printer.apply(app.createAips(ids, outputDir, strict, SimpleFilter(app.bagIndex)))
       case (THEMA, AIP) =>
-        printer.apply(app.simpleAips(ids, outputDir, strict, ThemaFilter(app.bagIndex)))
+        printer.apply(app.createAips(ids, outputDir, strict, ThemaFilter(app.bagIndex)))
       case tuple =>
         Failure(new NotImplementedError(s"$tuple not implemented"))
     }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -28,7 +28,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   editBuilder(_.setHelpWidth(110))
   printedName = "easy-fedora2vault"
   version(configuration.version)
-  val description: String = s"""Tool for exporting datasets from Fedora and constructing AIP-bags to be stored in the bag stores"""
+  val description: String = s"""Tool for exporting datasets from Fedora and constructing Information Packages."""
   val synopsis: String =
     s"""
        |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
@@ -54,7 +54,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     descr = "File containing a newline-separated list of easy-dataset-ids to be transformed. Use either this or the dataset-id argument")
   val inputFile: ScallopOption[File] = inputPath.map(File(_))
   private val outputDirPath: ScallopOption[Path] = opt(name = "output-dir", short = 'o', required = true,
-    descr = "Empty directory in which to stage the created AIP bags. It will be created if it doesn't exist.")
+    descr = "Empty directory in which to stage the created IPs. It will be created if it doesn't exist.")
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
   val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',
     descr = "The depositor for these datasets. If provided, only datasets from this depositor are transformed.")
@@ -65,7 +65,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val strictMode: ScallopOption[Boolean] = opt(name = "strict", short = 's',
     descr = "If provided, the transformation will check whether the datasets adhere to the requirements of the chosen transformation.")
   val transformation: ScallopOption[TransformationType] = trailArg(name = "transformation",
-    descr = s"The type of transformation used. Possible values: ${ TransformationType.values.mkString(", ") }.")
+    descr = TransformationType.values.mkString("The type of transformation used: ",", ","."))
 
   requireOne(datasetId, inputPath)
 

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -19,6 +19,7 @@ import java.nio.file.{ Path, Paths }
 
 import better.files.File
 import nl.knaw.dans.easy.fedora2vault.TransformationType.TransformationType
+import nl.knaw.dans.easy.fedora2vault.OutputFormat.OutputFormat
 import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter, singleArgConverter }
 
 import scala.xml.Properties
@@ -28,7 +29,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   editBuilder(_.setHelpWidth(110))
   printedName = "easy-fedora2vault"
   version(configuration.version)
-  val description: String = s"""Tool for exporting datasets from Fedora and constructing Information Packages."""
+  val description: String = s"""Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages."""
   val synopsis: String =
     s"""
        |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
@@ -47,6 +48,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |""".stripMargin)
 
   implicit val transformationTypeConverter: ValueConverter[TransformationType] = singleArgConverter(TransformationType.withName)
+  implicit val outputFormatConverter: ValueConverter[OutputFormat] = singleArgConverter(OutputFormat.withName)
 
   val datasetId: ScallopOption[DatasetId] = opt(name = "datasetId", short = 'd',
     descr = "A single easy-dataset-id to be transformed. Use either this or the input-file argument")
@@ -56,6 +58,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   private val outputDirPath: ScallopOption[Path] = opt(name = "output-dir", short = 'o', required = true,
     descr = "Empty directory in which to stage the created IPs. It will be created if it doesn't exist.")
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
+  val outputFormat: ScallopOption[OutputFormat] = opt(name = "output-format", short = 'f',
+    descr = OutputFormat.values.mkString("Output format: ",", ",". Only required for transformation type simple."))
   val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',
     descr = "The depositor for these datasets. If provided, only datasets from this depositor are transformed.")
   private val logFilePath: ScallopOption[Path] = opt(name = "log-file", short = 'l',

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -18,8 +18,8 @@ package nl.knaw.dans.easy.fedora2vault
 import java.nio.file.{ Path, Paths }
 
 import better.files.File
-import nl.knaw.dans.easy.fedora2vault.TransformationType.TransformationType
 import nl.knaw.dans.easy.fedora2vault.OutputFormat.OutputFormat
+import nl.knaw.dans.easy.fedora2vault.TransformationType.TransformationType
 import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter, singleArgConverter }
 
 import scala.xml.Properties
@@ -59,7 +59,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     descr = "Empty directory in which to stage the created IPs. It will be created if it doesn't exist.")
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
   val outputFormat: ScallopOption[OutputFormat] = opt(name = "output-format", short = 'f',
-    descr = OutputFormat.values.mkString("Output format: ",", ",". Only required for transformation type simple."))
+    descr = OutputFormat.values.mkString("Output format: ", ", ", ". Only required for transformation type simple."))
   val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',
     descr = "The depositor for these datasets. If provided, only datasets from this depositor are transformed.")
   private val logFilePath: ScallopOption[Path] = opt(name = "log-file", short = 'l',
@@ -69,7 +69,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val strictMode: ScallopOption[Boolean] = opt(name = "strict", short = 's',
     descr = "If provided, the transformation will check whether the datasets adhere to the requirements of the chosen transformation.")
   val transformation: ScallopOption[TransformationType] = trailArg(name = "transformation",
-    descr = TransformationType.values.mkString("The type of transformation used: ",", ","."))
+    descr = TransformationType.values.mkString("The type of transformation used: ", ", ", "."))
 
   requireOne(datasetId, inputPath)
 

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CommandLineOptions.scala
@@ -32,7 +32,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Tool for exporting datasets from Fedora and constructing Archival/Submission Information Packages."""
   val synopsis: String =
     s"""
-       |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} [-o <staged-AIP-dir>] [-u <depositor>] [-s] [-l <log-file>] <transformation>
+       |  easy-fedora2vault {-d <dataset-id> | -i <dataset-ids-file>} -o <staged-AIP-dir> [-s] [-l <log-file>] <transformation>
      """.stripMargin
 
   version(s"$printedName v${ configuration.version }")
@@ -60,8 +60,6 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val outputDir: ScallopOption[File] = outputDirPath.map(File(_))
   val outputFormat: ScallopOption[OutputFormat] = opt(name = "output-format", short = 'f',
     descr = OutputFormat.values.mkString("Output format: ", ", ", ". Only required for transformation type simple."))
-  val depositor: ScallopOption[Depositor] = opt(name = "depositor", short = 'u',
-    descr = "The depositor for these datasets. If provided, only datasets from this depositor are transformed.")
   private val logFilePath: ScallopOption[Path] = opt(name = "log-file", short = 'l',
     descr = s"The name of the logfile in csv format. If not provided a file $printedName-<timestamp>.csv will be created in the home-dir of the user.",
     default = Some(Paths.get(Properties.userHome).resolve(s"$printedName-$now.csv")))
@@ -71,7 +69,6 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val transformation: ScallopOption[TransformationType] = trailArg(name = "transformation",
     descr = TransformationType.values.mkString("The type of transformation used: ", ", ", "."))
 
-  requireOne(datasetId, inputPath)
 
   validatePathExists(inputPath)
   validatePathIsFile(inputPath)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/Configuration.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/Configuration.scala
@@ -27,6 +27,7 @@ case class Configuration(version: String,
                          fedoraCredentials: FedoraCredentials,
                          ldapEnv: LdapEnv,
                          bagIndexUrl: URI,
+                         stagingDir: File,
                         )
 
 object Configuration {
@@ -57,6 +58,7 @@ object Configuration {
         put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
       },
       new URI(properties.getString("bag-index.url")),
+      File(properties.getString("staging.dir")),
     )
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
@@ -15,9 +15,11 @@
  */
 package nl.knaw.dans.easy.fedora2vault
 
+import java.io.IOException
 import java.util.UUID
 
-import nl.knaw.dans.easy.fedora2vault.Command.FeedBackMessage
+import better.files.{ Dispose, File }
+import nl.knaw.dans.easy.fedora2vault.Command.{ FeedBackMessage, commandLine }
 import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 
 import scala.util.Try
@@ -41,4 +43,10 @@ object CsvRecord {
     .withDelimiter(',')
     .withRecordSeparator('\n')
     .withAutoFlush(true)
+
+  @throws[IOException]
+  def printer(file: File): Dispose[CSVPrinter] = {
+    val writer = file.newFileWriter(append = true)
+    new Dispose(csvFormat.print(writer))
+  }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
@@ -25,14 +25,14 @@ import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 import scala.util.Try
 
 case class CsvRecord(easyDatasetId: DatasetId,
-                     bagUUID: UUID,
+                     ipUUID: UUID,
                      doi: String,
                      depositor: Depositor,
                      transformationType: String,
                      comment: String,
                     ) {
   def print(implicit printer: CSVPrinter): Try[FeedBackMessage] = Try {
-    printer.printRecord(easyDatasetId, bagUUID, doi, depositor, transformationType, comment)
+    printer.printRecord(easyDatasetId, ipUUID, doi, depositor, transformationType, comment)
     comment
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/CsvRecord.scala
@@ -19,7 +19,7 @@ import java.io.IOException
 import java.util.UUID
 
 import better.files.{ Dispose, File }
-import nl.knaw.dans.easy.fedora2vault.Command.{ FeedBackMessage, commandLine }
+import nl.knaw.dans.easy.fedora2vault.Command.FeedBackMessage
 import org.apache.commons.csv.{ CSVFormat, CSVPrinter }
 
 import scala.util.Try

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/DepositProperties.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/DepositProperties.scala
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.fedora2vault
+
+import better.files.File
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone.UTC
+import org.joda.time.format.ISODateTimeFormat
+
+import scala.util.Try
+
+object DepositProperties {
+  private val dateTimeFormatter = ISODateTimeFormat.dateTimeNoMillis()
+
+  def create(depositDir: File, csvRecord: CsvRecord): Try[Unit] = Try {
+
+    val nowWithoutMillis: DatasetId = {
+      val now = DateTime.now(UTC)
+      now.minusMillis(now.millisOfSecond().get())
+    }.toString(dateTimeFormatter)
+
+    new PropertiesConfiguration() {
+      addProperty("creation.timestamp", nowWithoutMillis)
+      addProperty("state.label", "SUBMITTED")
+      addProperty("state.description", "Deposit is valid and ready for post-submission processing")
+      addProperty("depositor.userId", csvRecord.depositor)
+      addProperty("identifier.doi", csvRecord.doi)
+      addProperty("identifier.fedora", csvRecord.easyDatasetId)
+      addProperty("deposit.origin", "easy-fedora2vault")
+    }.save((depositDir / "deposit.properties").toJava)
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/DepositProperties.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/DepositProperties.scala
@@ -27,7 +27,6 @@ object DepositProperties {
   private val dateTimeFormatter = ISODateTimeFormat.dateTimeNoMillis()
 
   def create(depositDir: File, csvRecord: CsvRecord): Try[Unit] = Try {
-
     val nowWithoutMillis: DatasetId = {
       val now = DateTime.now(UTC)
       now.minusMillis(now.millisOfSecond().get())

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -70,7 +70,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       case t: FedoraClientException if t.getStatus != 404 => Failure(t)
       case t: Exception if t.isInstanceOf[IOException] => Failure(t)
       case t => Success(CsvRecord(
-        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE_AIP.toString, s"FAILED: $t"
+        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE.toString, s"FAILED: $t"
       ))
     }
       .doIfSuccess(_.print(printer))
@@ -136,7 +136,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       UUID.fromString(bagDir.name),
       doi,
       depositor,
-      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse(SIMPLE_AIP.toString),
+      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse(SIMPLE.toString),
       maybeTransformationViolations.getOrElse("OK"),
     )
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -63,20 +63,20 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
     val uuid = UUID.randomUUID.toString
     val depositDir = (configuration.stagingDir / uuid).createDirectories()
     val triedCsvRecord = for {
-      csvRecord <- simpleTransform(datasetId, depositDir / "bag", strict, filter)
+      csvRecord <- simpleAip(datasetId, depositDir / "bag", strict, filter)
       _ = (depositDir / "deposit.properties").write("") // TODO
       _ = depositDir.moveTo(outputDir / uuid)(CopyOptions.atomically)
     } yield csvRecord
     errorHandling(printer, triedCsvRecord, datasetId, depositDir)
   }
 
-  def simpleTransForms(input: Iterator[DatasetId], outputDir: File, strict: Boolean, filter: Filter)
-                      (printer: CSVPrinter): Try[FeedBackMessage] = input
-    .map(simpleTransform(_, outputDir / UUID.randomUUID.toString, strict, printer, filter))
+  def simpleAips(input: Iterator[DatasetId], outputDir: File, strict: Boolean, filter: Filter)
+                (printer: CSVPrinter): Try[FeedBackMessage] = input
+    .map(simpleAip(_, outputDir / UUID.randomUUID.toString, strict, printer, filter))
     .failFastOr(Success("no fedora/IO errors"))
 
-  private def simpleTransform(datasetId: DatasetId, bagDir: File, strict: Boolean, printer: CSVPrinter, filter: Filter): Try[Any] = {
-    val triedCsvRecord = simpleTransform(datasetId, bagDir, strict, filter)
+  private def simpleAip(datasetId: DatasetId, bagDir: File, strict: Boolean, printer: CSVPrinter, filter: Filter): Try[Any] = {
+    val triedCsvRecord = simpleAip(datasetId, bagDir, strict, filter)
     errorHandling(printer, triedCsvRecord, datasetId, bagDir)
   }
 
@@ -94,7 +94,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       }.doIfSuccess(_.print(printer))
   }
 
-  def simpleTransform(datasetId: DatasetId, bagDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
+  def simpleAip(datasetId: DatasetId, bagDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
 
     def managedMetadataStream(foXml: Elem, streamId: String, bag: DansV0Bag, metadataFile: String) = {
       managedStreamLabel(foXml, streamId)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -51,34 +51,34 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
   private lazy val ldap = new Ldap(ldapContext)
   private val emdUnmarshaller = new EmdUnmarshaller(classOf[EasyMetadataImpl])
 
-  def simpleSips(input: Iterator[DatasetId], outputDir: File, strict: Boolean, filter: Filter)
+  def createSips(input: Iterator[DatasetId], outputDir: File, strict: Boolean, filter: Filter)
                 (printer: CSVPrinter): Try[FeedBackMessage] = {
     input
-      .map(simpleSip(outputDir, strict, filter, printer))
+      .map(createSip(outputDir, strict, filter, printer))
       .failFastOr(Success("no fedora/IO errors"))
   }
 
-  private def simpleSip(outputDir: File, strict: Boolean, filter: Filter, printer: CSVPrinter)
+  private def createSip(outputDir: File, strict: Boolean, filter: Filter, printer: CSVPrinter)
                        (datasetId: DatasetId): Try[CsvRecord] = {
     val uuid = UUID.randomUUID.toString
     val depositDir = (configuration.stagingDir / uuid).createDirectories()
     val triedCsvRecord = for {
-      csvRecord <- simpleAip(datasetId, depositDir / "bag", strict, filter)
+      csvRecord <- createAip(datasetId, depositDir / "bag", strict, filter)
       _ <- DepositProperties.create(depositDir, csvRecord)
       _ = depositDir.moveTo(outputDir / uuid)(CopyOptions.atomically)
     } yield csvRecord
     errorHandling(printer, triedCsvRecord, datasetId, depositDir)
   }
 
-  def simpleAips(input: Iterator[DatasetId], outputDir: File, strict: Boolean, filter: Filter)
+  def createAips(input: Iterator[DatasetId], outputDir: File, strict: Boolean, filter: Filter)
                 (printer: CSVPrinter): Try[FeedBackMessage] = {
     input
-      .map(simpleAip(_, outputDir / UUID.randomUUID.toString, strict, printer, filter))
+      .map(createAip(_, outputDir / UUID.randomUUID.toString, strict, printer, filter))
       .failFastOr(Success("no fedora/IO errors"))
   }
 
-  private def simpleAip(datasetId: DatasetId, bagDir: File, strict: Boolean, printer: CSVPrinter, filter: Filter): Try[Any] = {
-    val triedCsvRecord = simpleAip(datasetId, bagDir, strict, filter)
+  private def createAip(datasetId: DatasetId, bagDir: File, strict: Boolean, printer: CSVPrinter, filter: Filter): Try[Any] = {
+    val triedCsvRecord = createAip(datasetId, bagDir, strict, filter)
     errorHandling(printer, triedCsvRecord, datasetId, bagDir)
   }
 
@@ -96,7 +96,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       }.doIfSuccess(_.print(printer))
   }
 
-  def simpleAip(datasetId: DatasetId, bagDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
+  def createAip(datasetId: DatasetId, bagDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
 
     def managedMetadataStream(foXml: Elem, streamId: String, bag: DansV0Bag, metadataFile: String) = {
       managedStreamLabel(foXml, streamId)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -62,7 +62,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
                 (printer: CSVPrinter): Try[FeedBackMessage] = input.map { datasetId =>
     val sipUUID = UUID.randomUUID.toString
     val bagUUID = UUID.randomUUID.toString
-    val depositDir = (configuration.stagingDir / sipUUID).createDirectories()
+    val depositDir = (configuration.stagingDir / sipUUID)
     // exceptions after createAip are fatal for the batch,
     // hence not reported in comment field of csvRecord
     val triedCsvRecord = for {

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/EasyFedora2vaultApp.scala
@@ -30,7 +30,7 @@ import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.fedora2vault.Command.FeedBackMessage
 import nl.knaw.dans.easy.fedora2vault.FileItem.{ checkNotImplemented, filesXml }
 import nl.knaw.dans.easy.fedora2vault.FoXml.{ getEmd, _ }
-import nl.knaw.dans.easy.fedora2vault.TransformationType.SIMPLE
+import nl.knaw.dans.easy.fedora2vault.TransformationType._
 import nl.knaw.dans.easy.fedora2vault.check._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -70,7 +70,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       case t: FedoraClientException if t.getStatus != 404 => Failure(t)
       case t: Exception if t.isInstanceOf[IOException] => Failure(t)
       case t => Success(CsvRecord(
-        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE.toString, s"FAILED: $t"
+        datasetId, UUID.fromString(bagDir.name), doi = "", depositor = "", SIMPLE_AIP.toString, s"FAILED: $t"
       ))
     }
       .doIfSuccess(_.print(printer))
@@ -136,7 +136,7 @@ class EasyFedora2vaultApp(configuration: Configuration) extends DebugEnhancedLog
       UUID.fromString(bagDir.name),
       doi,
       depositor,
-      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse("simple"),
+      transformationType = maybeTransformationViolations.map(_ => "not strict simple").getOrElse(SIMPLE_AIP.toString),
       maybeTransformationViolations.getOrElse("OK"),
     )
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/OutputFormat.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/OutputFormat.scala
@@ -15,11 +15,11 @@
  */
 package nl.knaw.dans.easy.fedora2vault
 
-object TransformationType extends Enumeration {
-  type TransformationType = Value
+object OutputFormat extends Enumeration {
+  type OutputFormat = Value
 
   // @formatter:off
-  val SIMPLE: TransformationType = Value("simple")
-  val THEMA: TransformationType = Value("thematische-collectie")
+  val AIP: OutputFormat = Value("AIP")
+  val SIP: OutputFormat = Value("SIP")
   // @formatter:on
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/TransformationType.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/TransformationType.scala
@@ -19,7 +19,8 @@ object TransformationType extends Enumeration {
   type TransformationType = Value
 
   // @formatter:off
-  val SIMPLE: TransformationType = Value("simple")
+  val SIMPLE_AIP: TransformationType = Value("simple-AIP")
+  val SIMPLE_SIP: TransformationType = Value("simple-SIP")
   val THEMA: TransformationType = Value("thematische-collectie")
   // @formatter:on
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/SimpleChecker.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/SimpleChecker.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.fedora2vault.check
 
 import nl.knaw.dans.easy.fedora2vault.BagIndex
 
-case class SimpleChecker(override val bagIndex: BagIndex) extends TransformationChecker {
+class SimpleChecker(override val bagIndex: BagIndex) extends TransformationChecker {
   override def forbiddenTitle(title: String): Boolean = {
     title.toLowerCase.contains("thematische collectie")
   }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/ThemaChecker.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/check/ThemaChecker.scala
@@ -17,8 +17,6 @@ package nl.knaw.dans.easy.fedora2vault.check
 
 import nl.knaw.dans.easy.fedora2vault.BagIndex
 
-case class ThemaChecker(override val bagIndex: BagIndex) extends TransformationChecker {
-  override def forbiddenTitle(title: String): Boolean = {
-    !title.toLowerCase.contains("thematische collectie")
-  }
+class ThemaChecker(override val bagIndex: BagIndex) extends SimpleChecker(bagIndex) {
+  override def forbiddenTitle(title: String): Boolean = !super.forbiddenTitle(title)
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/BagIndex.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/BagIndex.scala
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.fedora2vault
+package nl.knaw.dans.easy.fedora2vault.filter
 
 import java.io.IOException
 import java.net.URI
+import nl.knaw.dans.easy.fedora2vault._
 
 import better.files.StringExtensions
 import scalaj.http.{ Http, HttpResponse }
@@ -24,14 +25,14 @@ import scalaj.http.{ Http, HttpResponse }
 import scala.util.{ Failure, Try }
 import scala.xml.XML
 
-case class BagIndex(bagIndexUri: URI) {
+case class BagIndex(bagIndexUri: URI) extends TargetIndex {
 
   /** An IOException is fatal for the batch of datasets */
   private case class BagIndexException(msg: String, cause: Throwable) extends IOException(msg, cause)
 
   private val url: URI = bagIndexUri.resolve("/search")
 
-  def bagInfoByDoi(doi: String): Try[Option[String]] = for {
+  override def getByDoi(doi: String): Try[Option[String]] = for {
     maybeString <- findBagInfo(doi)
     maybeXml = maybeString.map(s => XML.load(s.inputStream))
     maybeBagInfo = maybeXml.flatMap(xml => (xml \ "bag-info").theSeq.headOption)

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/BagIndex.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/BagIndex.scala
@@ -17,9 +17,9 @@ package nl.knaw.dans.easy.fedora2vault.filter
 
 import java.io.IOException
 import java.net.URI
-import nl.knaw.dans.easy.fedora2vault._
 
 import better.files.StringExtensions
+import nl.knaw.dans.easy.fedora2vault._
 import scalaj.http.{ Http, HttpResponse }
 
 import scala.util.{ Failure, Try }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/Filter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/Filter.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.fedora2vault.check
+package nl.knaw.dans.easy.fedora2vault.filter
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory.{ OPEN_ACCESS, REQUEST_PERMISSION }
 import nl.knaw.dans.easy.fedora2vault._
@@ -25,13 +25,13 @@ import scala.xml.Node
 
 case class InvalidTransformationException(msg: String) extends Exception(msg)
 
-trait TransformationChecker extends DebugEnhancedLogging {
-  val bagIndex: BagIndex
+trait Filter extends DebugEnhancedLogging {
+  val targetIndex: TargetIndex
 
   def violations(emd: EasyMetadataImpl, ddm: Node, amd: Node, fedoraIDs: Seq[String]): Try[Option[String]] = {
     val maybeDoi = Option(emd.getEmdIdentifier.getDansManagedDoi)
     val triedMaybeVaultResponse: Try[Option[String]] = maybeDoi
-      .map(bagIndex.bagInfoByDoi)
+      .map(targetIndex.getByDoi)
       .getOrElse(Success(None)) // no DOI => no bag found by DOI
     val violations = Seq(
       "1: DANS DOI" -> (if (maybeDoi.isEmpty) Seq("not found")

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/SimpleFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/SimpleFilter.scala
@@ -15,8 +15,12 @@
  */
 package nl.knaw.dans.easy.fedora2vault.filter
 
-class SimpleFilter(override val targetIndex: TargetIndex) extends Filter {
+class SimpleFilter(override val targetIndex: TargetIndex = new TargetIndex()) extends Filter {
   override def forbiddenTitle(title: String): Boolean = {
     title.toLowerCase.contains("thematische collectie")
   }
+}
+object SimpleFilter {
+  def apply(targetIndex: TargetIndex = new TargetIndex()) =
+    new SimpleFilter(targetIndex)
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/SimpleFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/SimpleFilter.scala
@@ -13,23 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.fedora2vault.fixture
+package nl.knaw.dans.easy.fedora2vault.filter
 
-import java.net.URI
-
-import nl.knaw.dans.easy.fedora2vault.filter.BagIndex
-import scalaj.http.HttpResponse
-
-trait BagIndexSupport {
-  /**
-   * Limited to test scenarios where the BagIndex service
-   * always gives the the same response
-   */
-  def mockBagIndexRespondsWith(body: String, code: Int): BagIndex = {
-    new BagIndex(new URI("https://does.not.exist.dans.knaw.nl:20120")) {
-      override def execute(doi: String): HttpResponse[String] = {
-        new HttpResponse[String](body, code, headers = Map.empty)
-      }
-    }
+class SimpleFilter(override val targetIndex: TargetIndex) extends Filter {
+  override def forbiddenTitle(title: String): Boolean = {
+    title.toLowerCase.contains("thematische collectie")
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/TargetIndex.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/TargetIndex.scala
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.fedora2vault.check
+package nl.knaw.dans.easy.fedora2vault.filter
 
-import nl.knaw.dans.easy.fedora2vault.BagIndex
+import scala.util.{ Success, Try }
 
-class SimpleChecker(override val bagIndex: BagIndex) extends TransformationChecker {
-  override def forbiddenTitle(title: String): Boolean = {
-    title.toLowerCase.contains("thematische collectie")
-  }
+class TargetIndex {
+
+  // override to check for existence in an external source
+  def getByDoi(doi: String): Try[Option[String]] = Success(None)
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/ThemaFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/ThemaFilter.scala
@@ -15,6 +15,6 @@
  */
 package nl.knaw.dans.easy.fedora2vault.filter
 
-class ThemaFilter(override val targetIndex: BagIndex) extends SimpleFilter(targetIndex) {
+case class ThemaFilter(override val targetIndex: BagIndex) extends SimpleFilter(targetIndex) {
   override def forbiddenTitle(title: String): Boolean = !super.forbiddenTitle(title)
 }

--- a/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/ThemaFilter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/fedora2vault/filter/ThemaFilter.scala
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.fedora2vault.check
+package nl.knaw.dans.easy.fedora2vault.filter
 
-import nl.knaw.dans.easy.fedora2vault.BagIndex
-
-class ThemaChecker(override val bagIndex: BagIndex) extends SimpleChecker(bagIndex) {
+class ThemaFilter(override val targetIndex: BagIndex) extends SimpleFilter(targetIndex) {
   override def forbiddenTitle(title: String): Boolean = !super.forbiddenTitle(title)
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -7,3 +7,5 @@ fcrepo.password=fedoraAdmin
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
+
+staging.dir=/var/opt/dans.knaw.nl/tmp/easy-fedora2vault/staged

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -53,7 +53,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
   private class OverriddenApp(configuration: Configuration = null) extends MockedApp(configuration) {
     /** overrides the method called by the method under test */
-    override def simpleTransform(datasetId: DatasetId, outputDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
+    override def simpleAip(datasetId: DatasetId, outputDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
           Failure(new FedoraClientException(300, "mocked exception"))
@@ -84,12 +84,12 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     files.filter(_.name == "deposit.properties") should have length 2
   }
 
-  "simpleTransforms" should "report success" in {
+  "simpleAips" should "report success" in {
     val ids = Iterator("success:1", "success:2")
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
     val app = new OverriddenApp()
-    app.simpleTransForms(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+    app.simpleAips(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
     sw.toString should (fullyMatch regex
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK
@@ -104,7 +104,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
     val app = new OverriddenApp()
-    app.simpleTransForms(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) should matchPattern {
+    app.simpleAips(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) should matchPattern {
       case Failure(t) if t.getMessage == "mocked exception" =>
     }
     sw.toString should (fullyMatch regex
@@ -118,7 +118,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     outputDir.list.toSeq should have length 4
   }
 
-  "simpleTransform" should "process DepositApi" in {
+  "simpleAip" should "process DepositApi" in {
     val app = new MockedApp()
     implicit val fedoraProvider: FedoraProvider = app.fedoraProvider
     expectedAudiences(Map("easy-discipline:77" -> "D13200"))
@@ -130,7 +130,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     )
 
     val uuid = UUID.randomUUID
-    app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
+    app.simpleAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -154,7 +154,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     )
 
     val uuid = UUID.randomUUID
-    app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false, app.filter) shouldBe
+    app.simpleAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "not strict simple", "Violates 2: has jump off"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -174,7 +174,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedFoXmls(app.fedoraProvider, sampleFoXML / "DepositApi.xml")
 
     val uuid = UUID.randomUUID
-    app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) should matchPattern {
+    app.simpleAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) should matchPattern {
       case Failure(_: InvalidTransformationException) =>
     }
 
@@ -193,7 +193,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedManagedStreams(app.fedoraProvider, mockContentOfFile35)
 
     val uuid = UUID.randomUUID
-    app.simpleTransform("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
+    app.simpleAip("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -228,7 +228,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedSubordinates(app.fedoraProvider, "easy-file:35")
     expectedManagedStreams(app.fedoraProvider, mockContentOfFile35)
 
-    app.simpleTransform("easy-dataset:13", testDir / "bags" / UUID.randomUUID.toString, strict = true, app.filter) should matchPattern {
+    app.simpleAip("easy-dataset:13", testDir / "bags" / UUID.randomUUID.toString, strict = true, app.filter) should matchPattern {
       case Failure(e) if e.getMessage == "easy-file:35 <visibleTo> not found" =>
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -53,7 +53,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
   private class OverriddenApp(configuration: Configuration = null) extends MockedApp(configuration) {
     /** overrides the method called by the method under test */
-    override def createAip(datasetId: DatasetId, outputDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
+    override def createBag(datasetId: DatasetId, outputDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
           Failure(new FedoraClientException(300, "mocked exception"))
@@ -149,7 +149,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     )
 
     val uuid = UUID.randomUUID
-    app.createAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
+    app.createBag("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -173,7 +173,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     )
 
     val uuid = UUID.randomUUID
-    app.createAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false, app.filter) shouldBe
+    app.createBag("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "not strict simple", "Violates 2: has jump off"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -193,7 +193,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedFoXmls(app.fedoraProvider, sampleFoXML / "DepositApi.xml")
 
     val uuid = UUID.randomUUID
-    app.createAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) should matchPattern {
+    app.createBag("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) should matchPattern {
       case Failure(_: InvalidTransformationException) =>
     }
 
@@ -212,7 +212,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedManagedStreams(app.fedoraProvider, mockContentOfFile35)
 
     val uuid = UUID.randomUUID
-    app.createAip("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
+    app.createBag("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -247,7 +247,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedSubordinates(app.fedoraProvider, "easy-file:35")
     expectedManagedStreams(app.fedoraProvider, mockContentOfFile35)
 
-    app.createAip("easy-dataset:13", testDir / "bags" / UUID.randomUUID.toString, strict = true, app.filter) should matchPattern {
+    app.createBag("easy-dataset:13", testDir / "bags" / UUID.randomUUID.toString, strict = true, app.filter) should matchPattern {
       case Failure(e) if e.getMessage == "easy-file:35 <visibleTo> not found" =>
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -47,7 +47,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     override lazy val fedoraProvider: FedoraProvider = mock[FedoraProvider]
     override lazy val ldapContext: InitialLdapContext = mock[MockedLdapContext]
     override lazy val bagIndex: BagIndex = mockedBagIndex
-    val simpleChecker: SimpleChecker = SimpleChecker(bagIndex)
+    val simpleChecker: SimpleChecker = new SimpleChecker(bagIndex)
   }
 
   private class OverriddenApp extends MockedApp {

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -96,8 +96,8 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     sw.toString should (fullyMatch regex
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK
-        |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
-        |notSimple:3,.*,,,simple,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
+        |failure:2,.*,,,simple-AIP,FAILED: java.lang.Exception: failure:2
+        |notSimple:3,.*,,,simple-AIP,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
         |success:4,.*,,,simple,OK
         |""".stripMargin
       )
@@ -117,7 +117,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
+      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
     (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
@@ -180,7 +180,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
+      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -23,7 +23,7 @@ import com.yourmediashelf.fedora.client.FedoraClientException
 import javax.naming.NamingEnumeration
 import javax.naming.directory.{ BasicAttributes, SearchControls, SearchResult }
 import javax.naming.ldap.InitialLdapContext
-import nl.knaw.dans.easy.fedora2vault.check.{ InvalidTransformationException, SimpleChecker, TransformationChecker }
+import nl.knaw.dans.easy.fedora2vault.filter.{ BagIndex, Filter, InvalidTransformationException, SimpleFilter }
 import nl.knaw.dans.easy.fedora2vault.fixture.{ AudienceSupport, BagIndexSupport, FileSystemSupport, TestSupportFixture }
 import org.scalamock.scalatest.MockFactory
 import resource.managed
@@ -47,13 +47,13 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     override lazy val fedoraProvider: FedoraProvider = mock[FedoraProvider]
     override lazy val ldapContext: InitialLdapContext = mock[MockedLdapContext]
     override lazy val bagIndex: BagIndex = mockedBagIndex
-    val simpleChecker: SimpleChecker = new SimpleChecker(bagIndex)
+    val simpleChecker: SimpleFilter = new SimpleFilter(bagIndex)
   }
 
   private class OverriddenApp extends MockedApp {
     /** overrides the method called by the method under test */
     override def simpleTransform(datasetId: DatasetId, outputDir: File, strict: Boolean)
-                                (implicit transformationChecker: TransformationChecker): Try[CsvRecord] = {
+                                (implicit transformationChecker: Filter): Try[CsvRecord] = {
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
           Failure(new FedoraClientException(300, "mocked exception"))
@@ -97,7 +97,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK
         |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
-        |notSimple:3,.*,,,simple,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
+        |notSimple:3,.*,,,simple,FAILED: .*InvalidTransformationException: mocked
         |success:4,.*,,,simple,OK
         |""".stripMargin
       )

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -50,7 +50,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     override lazy val bagIndex: BagIndex = mockedBagIndex
     val filter: SimpleFilter = SimpleFilter(bagIndex)
 
-    // make protected method available for tests
+    // make almost private method available for tests
     override def createBag(datasetId: DatasetId, bagDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] =
       super.createBag(datasetId, bagDir, strict, filter)
   }
@@ -58,6 +58,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
   private class OverriddenApp(configuration: Configuration = null) extends MockedApp(configuration) {
     /** overrides the method called by the method under test */
     override def createBag(datasetId: DatasetId, outputDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
+      outputDir.parent.createDirectories()
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
           Failure(new FedoraClientException(300, "mocked exception"))

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -79,7 +79,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     triedMessage shouldBe Success("no fedora/IO errors")
 
     val files = outputDir.listRecursively.toSeq
-    files should have length 6 // two directories plus two files each
+    files should have length 6 // two directories with two entries each
     files.filter(_.name == "bag") should have length 2
     val props = files.filter(_.name == "deposit.properties")
     props should have length 2

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -70,7 +70,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     }
   }
 
-  "simpleSips" should "report success" in pendingUntilFixed {
+  "simpleSips" should "report success" in {
     val ids = Iterator("success:1", "notSimple:3", "success:2")
     val outputDir = (testDir / "output").createDirectories()
     val app = new OverriddenApp(Configuration(null, null, null, null, testDir / "staging"))

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -96,8 +96,8 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     sw.toString should (fullyMatch regex
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,,,simple,OK
-        |failure:2,.*,,,simple-AIP,FAILED: java.lang.Exception: failure:2
-        |notSimple:3,.*,,,simple-AIP,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
+        |failure:2,.*,,,simple,FAILED: java.lang.Exception: failure:2
+        |notSimple:3,.*,,,simple,FAILED: nl.knaw.dans.easy.fedora2vault.check.InvalidTransformationException: mocked
         |success:4,.*,,,simple,OK
         |""".stripMargin
       )
@@ -117,7 +117,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
+      Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
     (metadata / "depositor-info/depositor-agreement.pdf").contentAsString shouldBe "blablabla"
@@ -180,7 +180,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
     val uuid = UUID.randomUUID
     app.simpleTransform("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true)(app.simpleChecker) shouldBe
-      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple-AIP", "OK"))
+      Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -53,7 +53,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
 
   private class OverriddenApp(configuration: Configuration = null) extends MockedApp(configuration) {
     /** overrides the method called by the method under test */
-    override def simpleAip(datasetId: DatasetId, outputDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
+    override def createAip(datasetId: DatasetId, outputDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] = {
       datasetId match {
         case _ if datasetId.startsWith("fatal") =>
           Failure(new FedoraClientException(300, "mocked exception"))
@@ -70,12 +70,12 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     }
   }
 
-  "simpleSips" should "report success" in {
+  "createSips" should "report success" in {
     val ids = Iterator("success:1", "notSimple:1", "success:1")
     val outputDir = (testDir / "output").createDirectories()
     val app = new OverriddenApp(Configuration(null, null, null, null, testDir / "staging"))
     val printer = CsvRecord.csvFormat.print(new StringWriter()) // content verified with simpleTransforms
-    val triedMessage = app.simpleSips(ids, outputDir, strict = true, SimpleFilter())(printer)
+    val triedMessage = app.createSips(ids, outputDir, strict = true, SimpleFilter())(printer)
     triedMessage shouldBe Success("no fedora/IO errors")
 
     val files = outputDir.listRecursively.toSeq
@@ -96,12 +96,12 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     file.contentAsString.split("\n").filterNot(_.contains("timestamp")).mkString("\n")
   }
 
-  "simpleAips" should "report success" in {
+  "createAips" should "report success" in {
     val ids = Iterator("success:1", "success:2")
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
     val app = new OverriddenApp()
-    app.simpleAips(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
+    app.createAips(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) shouldBe Success("no fedora/IO errors")
     sw.toString should (fullyMatch regex
       """easyDatasetId,uuid,doi,depositor,transformationType,comment
         |success:1,.*,testDOI,testUser,simple,OK
@@ -116,7 +116,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     val outputDir = (testDir / "output").createDirectories()
     val sw = new StringWriter()
     val app = new OverriddenApp()
-    app.simpleAips(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) should matchPattern {
+    app.createAips(ids, outputDir, strict = true, app.filter)(CsvRecord.csvFormat.print(sw)) should matchPattern {
       case Failure(t) if t.getMessage == "mocked exception" =>
     }
     sw.toString should (fullyMatch regex
@@ -130,7 +130,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     outputDir.list.toSeq should have length 4
   }
 
-  "simpleAip" should "process DepositApi" in {
+  "createAip" should "process DepositApi" in {
     val app = new MockedApp()
     implicit val fedoraProvider: FedoraProvider = app.fedoraProvider
     expectedAudiences(Map("easy-discipline:77" -> "D13200"))
@@ -142,7 +142,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     )
 
     val uuid = UUID.randomUUID
-    app.simpleAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
+    app.createAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -166,7 +166,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     )
 
     val uuid = UUID.randomUUID
-    app.simpleAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false, app.filter) shouldBe
+    app.createAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = false, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:17", uuid, "10.17026/test-Iiib-z9p-4ywa", "user001", "not strict simple", "Violates 2: has jump off"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -186,7 +186,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedFoXmls(app.fedoraProvider, sampleFoXML / "DepositApi.xml")
 
     val uuid = UUID.randomUUID
-    app.simpleAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) should matchPattern {
+    app.createAip("easy-dataset:17", testDir / "bags" / uuid.toString, strict = true, app.filter) should matchPattern {
       case Failure(_: InvalidTransformationException) =>
     }
 
@@ -205,7 +205,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedManagedStreams(app.fedoraProvider, mockContentOfFile35)
 
     val uuid = UUID.randomUUID
-    app.simpleAip("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
+    app.createAip("easy-dataset:13", testDir / "bags" / uuid.toString, strict = true, app.filter) shouldBe
       Success(CsvRecord("easy-dataset:13", uuid, "10.17026/mocked-Iiib-z9p-4ywa", "user001", "simple", "OK"))
 
     val metadata = (testDir / "bags").children.next() / "metadata"
@@ -240,7 +240,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     expectedSubordinates(app.fedoraProvider, "easy-file:35")
     expectedManagedStreams(app.fedoraProvider, mockContentOfFile35)
 
-    app.simpleAip("easy-dataset:13", testDir / "bags" / UUID.randomUUID.toString, strict = true, app.filter) should matchPattern {
+    app.createAip("easy-dataset:13", testDir / "bags" / UUID.randomUUID.toString, strict = true, app.filter) should matchPattern {
       case Failure(e) if e.getMessage == "easy-file:35 <visibleTo> not found" =>
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/AppSpec.scala
@@ -49,6 +49,10 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     override lazy val ldapContext: InitialLdapContext = mock[MockedLdapContext]
     override lazy val bagIndex: BagIndex = mockedBagIndex
     val filter: SimpleFilter = SimpleFilter(bagIndex)
+
+    // make protected method available for tests
+    override def createBag(datasetId: DatasetId, bagDir: File, strict: Boolean, filter: Filter): Try[CsvRecord] =
+      super.createBag(datasetId, bagDir, strict, filter)
   }
 
   private class OverriddenApp(configuration: Configuration = null) extends MockedApp(configuration) {
@@ -90,7 +94,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     // two deposits with almost the same deposit.properties
     val props = outputDir.listRecursively.toList.filter(_.name == "deposit.properties")
     props should have length 2
-    props.map(linesWithoutTimestamp).toList.distinct shouldBe List(
+    props.map(linesWithoutTimestamp).distinct shouldBe List(
       """state.label = SUBMITTED
         |state.description = Deposit is valid and ready for post-submission processing
         |depositor.userId = testUser
@@ -137,7 +141,7 @@ class AppSpec extends TestSupportFixture with BagIndexSupport with MockFactory w
     outputDir.list.toSeq should have length 4
   }
 
-  "createAip" should "process DepositApi" in {
+  "createBag" should "process DepositApi" in {
     val app = new MockedApp()
     implicit val fedoraProvider: FedoraProvider = app.fedoraProvider
     expectedAudiences(Map("easy-discipline:77" -> "D13200"))

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/BagIndexSpec.scala
@@ -25,22 +25,22 @@ class BagIndexSpec extends TestSupportFixture with BagIndexSupport with MockFact
 
   "bagInfoByDoi" should "return None" in {
     mockBagIndexRespondsWith(body = "", code = 404)
-      .bagInfoByDoi("") shouldBe Success(None)
+      .getByDoi("") shouldBe Success(None)
   }
 
   it should "return also None" in {
     mockBagIndexRespondsWith(body = "<result/>", code = 200)
-      .bagInfoByDoi("") shouldBe Success(None)
+      .getByDoi("") shouldBe Success(None)
   }
 
   it should "return Some" in {
     mockBagIndexRespondsWith(body = "<result><bag-info>blabla</bag-info></result>", code = 200)
-      .bagInfoByDoi("") shouldBe Success(Some("<bag-info>blabla</bag-info>"))
+      .getByDoi("") shouldBe Success(Some("<bag-info>blabla</bag-info>"))
   }
 
   it should "return SAXParseException" in {
     mockBagIndexRespondsWith(body = "", code = 200)
-      .bagInfoByDoi("") should matchPattern {
+      .getByDoi("") should matchPattern {
       case Failure(e: SAXParseException) if e.getMessage ==
         "Premature end of file." =>
     }
@@ -48,7 +48,7 @@ class BagIndexSpec extends TestSupportFixture with BagIndexSupport with MockFact
 
   it should "return not expected response code" in {
     mockBagIndexRespondsWith(body = "", code = 300)
-      .bagInfoByDoi("") should matchPattern {
+      .getByDoi("") should matchPattern {
       case Failure(e: Exception) if e.getMessage ==
         "Not expected response code from bag-index. url='https://does.not.exist.dans.knaw.nl:20120/search', doi='', response: 300 - " =>
     }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/DdmSpec.scala
@@ -24,6 +24,7 @@ import scala.util.{ Failure, Success, Try }
 import scala.xml._
 
 class DdmSpec extends TestSupportFixture with EmdSupport with AudienceSupport with SchemaSupport {
+  System.setProperty("http.agent", "Test")
 
   override val schema = "https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd"
 

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/FilterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/FilterSpec.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.fedora2vault
 import java.net.URI
 
 import com.typesafe.scalalogging.Logger
-import nl.knaw.dans.easy.fedora2vault.check.{ SimpleChecker, ThemaChecker }
+import nl.knaw.dans.easy.fedora2vault.filter.{ BagIndex, SimpleFilter, ThemaFilter }
 import nl.knaw.dans.easy.fedora2vault.fixture.{ BagIndexSupport, EmdSupport, TestSupportFixture }
 import org.scalamock.scalatest.MockFactory
 import org.slf4j.{ Logger => UnderlyingLogger }
@@ -26,7 +26,7 @@ import org.slf4j.{ Logger => UnderlyingLogger }
 import scala.util.Success
 import scala.xml.Elem
 
-class TransformationCheckerSpec extends TestSupportFixture with BagIndexSupport with MockFactory with EmdSupport {
+class FilterSpec extends TestSupportFixture with BagIndexSupport with MockFactory with EmdSupport {
 
   private class MockedBagIndex extends BagIndex(new URI("http://localhost:20120/"))
 
@@ -155,7 +155,7 @@ class TransformationCheckerSpec extends TestSupportFixture with BagIndexSupport 
       (mockLogger.warn(_: String)) expects s once()
     )
 
-    new SimpleChecker(bagIndex) {
+    new SimpleFilter(bagIndex) {
       override lazy val logger: Logger = Logger(mockLogger)
     }
   }
@@ -169,7 +169,7 @@ class TransformationCheckerSpec extends TestSupportFixture with BagIndexSupport 
       (mockLogger.warn(_: String)) expects s once()
     )
 
-    new ThemaChecker(bagIndex) {
+    new ThemaFilter(bagIndex) {
       override lazy val logger: Logger = Logger(mockLogger)
     }
   }

--- a/src/test/scala/nl/knaw/dans/easy/fedora2vault/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/fedora2vault/ReadmeSpec.scala
@@ -29,6 +29,7 @@ class ReadmeSpec extends TestSupportFixture with CustomMatchers with FixedCurren
     fedoraCredentials = null,
     ldapEnv = null,
     bagIndexUrl = null,
+    stagingDir = null,
   )
   Properties.setProp("user.home", "/home/vagrant")
   private val clo = new CommandLineOptions(Array[String](), configuration) {


### PR DESCRIPTION
Fixes DD-112: enable deposit-dir export

#### When applied it will...
* have a new command line argument `--output-format` (short `-f`), values: `AIP` or `SIP`
* not check for existence in the vault in case of SIP, so strict mode is possible
* [x] not (yet?) put the urn in the deposit.properties
* have a new application.property: `staging.dir`
* [x] ~~may leave (lots of?) empty directories in the staged directory
  for example for datasets that don't exist or are not simple while strict was specified~~

#### Where should the reviewer @DANS-KNAW/dataverseDANS start ?

Functional
* The new Unit test AppSpec.simpleSips
* [x] no rename of the project from `easy-fedora2fault` to something like `easy-fedora-to-ip`
  ~~Perhaps~~ a separate pull request?

Rafactored:
* renamed `check` methods/package to `filter`s
* moved `BagIndex` to `filter` package
* renamed simpleTransform(s) -> createSips/createAips/createBag, reduced chain of methods
* signatures of the renamed methods also changed

#### How should this be manually tested?

#### Related pull requests on github
requires for deploy
* [x] https://github.com/DANS-KNAW/easy-dtap/pull/482
* [-] ~~dd-dtap~~
